### PR TITLE
Add gh_pr_create_draft MCP tool

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -82,6 +82,34 @@ export class BranchNotFoundError extends Error {
   }
 }
 
+export class DraftPrsDisabledError extends Error {
+  constructor(repoPath: string) {
+    super(`draft PR creation is disabled for repository '${repoPath}'`);
+    this.name = "DraftPrsDisabledError";
+  }
+}
+
+export class EmptyPullRequestTitleError extends Error {
+  constructor() {
+    super("pull request title must be non-empty");
+    this.name = "EmptyPullRequestTitleError";
+  }
+}
+
+export class PullRequestBaseBranchError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "PullRequestBaseBranchError";
+  }
+}
+
+export class PullRequestUrlParseError extends Error {
+  constructor(output: string) {
+    super(`could not parse pull request URL from gh output: ${output.trim() || "empty output"}`);
+    this.name = "PullRequestUrlParseError";
+  }
+}
+
 export class CommandExecutionError extends Error {
   public readonly command: string;
   public readonly args: string[];

--- a/src/exec/gh.ts
+++ b/src/exec/gh.ts
@@ -1,36 +1,17 @@
 import { runCommand } from "./run.js";
 
-export function ghPrCreateDraftArgs(args: {
-  base: string;
-  fill?: boolean;
-  title?: string;
-  body?: string;
-}): string[] {
-  const argv = ["pr", "create", "--draft", "--base", args.base];
-
-  if (args.fill) {
-    argv.push("--fill");
-  }
-
-  if (args.title !== undefined) {
-    argv.push("--title", args.title);
-  }
-
-  if (args.body !== undefined) {
-    argv.push("--body", args.body);
-  }
-
-  return argv;
+export function ghPrCreateDraftArgs(base: string, title: string, body: string): string[] {
+  return ["pr", "create", "--draft", "--base", base, "--title", title, "--body", body];
 }
 
 export async function createDraftPullRequest(
   cwd: string,
-  args: { base: string; fill?: boolean; title?: string; body?: string },
+  args: { base: string; title: string; body: string },
 ): Promise<string> {
   const result = await runCommand({
     cwd,
     command: "gh",
-    argv: ghPrCreateDraftArgs(args),
+    argv: ghPrCreateDraftArgs(args.base, args.title, args.body),
   });
 
   return result.stdout.trim();

--- a/src/exec/gh.ts
+++ b/src/exec/gh.ts
@@ -1,0 +1,18 @@
+import { runCommand } from "./run.js";
+
+export function ghPrCreateDraftArgs(base: string, title: string, body: string): string[] {
+  return ["pr", "create", "--draft", "--base", base, "--title", title, "--body", body];
+}
+
+export async function createDraftPullRequest(
+  cwd: string,
+  args: { base: string; title: string; body: string },
+): Promise<string> {
+  const result = await runCommand({
+    cwd,
+    command: "gh",
+    argv: ghPrCreateDraftArgs(args.base, args.title, args.body),
+  });
+
+  return result.stdout.trim();
+}

--- a/src/exec/gh.ts
+++ b/src/exec/gh.ts
@@ -1,17 +1,36 @@
 import { runCommand } from "./run.js";
 
-export function ghPrCreateDraftArgs(base: string, title: string, body: string): string[] {
-  return ["pr", "create", "--draft", "--base", base, "--title", title, "--body", body];
+export function ghPrCreateDraftArgs(args: {
+  base: string;
+  fill?: boolean;
+  title?: string;
+  body?: string;
+}): string[] {
+  const argv = ["pr", "create", "--draft", "--base", args.base];
+
+  if (args.fill) {
+    argv.push("--fill");
+  }
+
+  if (args.title !== undefined) {
+    argv.push("--title", args.title);
+  }
+
+  if (args.body !== undefined) {
+    argv.push("--body", args.body);
+  }
+
+  return argv;
 }
 
 export async function createDraftPullRequest(
   cwd: string,
-  args: { base: string; title: string; body: string },
+  args: { base: string; fill?: boolean; title?: string; body?: string },
 ): Promise<string> {
   const result = await runCommand({
     cwd,
     command: "gh",
-    argv: ghPrCreateDraftArgs(args.base, args.title, args.body),
+    argv: ghPrCreateDraftArgs(args),
   });
 
   return result.stdout.trim();

--- a/src/server.ts
+++ b/src/server.ts
@@ -7,6 +7,7 @@ import { resolveAllowedRepo } from "./auth/repoAuth.js";
 import { gitAdd } from "./tools/gitAdd.js";
 import { gitBranchCreate } from "./tools/gitBranchCreate.js";
 import { gitBranchSwitch } from "./tools/gitBranchSwitch.js";
+import { ghPrCreateDraft } from "./tools/ghPrCreateDraft.js";
 import { gitCommit } from "./tools/gitCommit.js";
 import { gitPush } from "./tools/gitPush.js";
 import { getGitStatus } from "./tools/gitStatus.js";
@@ -139,6 +140,31 @@ export function createServer(config: Config): McpServer {
       const repo = await resolveAllowedRepo(config, repo_path);
       const branch = await requireAllowedBranch(repo);
       const result = await gitPush(repo, branch);
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(result, null, 2),
+          },
+        ],
+      };
+    },
+  );
+
+  server.tool(
+    "gh_pr_create_draft",
+    "Create a draft pull request for the current branch in an allowlisted repository. This tool mutates repository state via GitHub, requires the current branch to match configured full-match patterns, is draft-only, and constrains the base branch to repository policy.",
+    {
+      repo_path: z.string().min(1),
+      title: z.string(),
+      body: z.string(),
+      base: z.string().min(1).optional(),
+    },
+    async ({ repo_path, title, body, base }) => {
+      const repo = await resolveAllowedRepo(config, repo_path);
+      const branch = await requireAllowedBranch(repo);
+      const result = await ghPrCreateDraft(repo, branch, { title, body, base });
 
       return {
         content: [

--- a/src/server.ts
+++ b/src/server.ts
@@ -157,15 +157,14 @@ export function createServer(config: Config): McpServer {
     "Create a draft pull request for the current branch in an allowlisted repository. This tool mutates repository state via GitHub, requires the current branch to match configured full-match patterns, is draft-only, and constrains the base branch to repository policy.",
     {
       repo_path: z.string().min(1),
-      title: z.string().optional(),
-      body: z.string().optional(),
+      title: z.string(),
+      body: z.string(),
       base: z.string().min(1).optional(),
-      fill: z.boolean().optional(),
     },
-    async ({ repo_path, title, body, base, fill }) => {
+    async ({ repo_path, title, body, base }) => {
       const repo = await resolveAllowedRepo(config, repo_path);
       const branch = await requireAllowedBranch(repo);
-      const result = await ghPrCreateDraft(repo, branch, { title, body, base, fill });
+      const result = await ghPrCreateDraft(repo, branch, { title, body, base });
 
       return {
         content: [

--- a/src/server.ts
+++ b/src/server.ts
@@ -157,14 +157,15 @@ export function createServer(config: Config): McpServer {
     "Create a draft pull request for the current branch in an allowlisted repository. This tool mutates repository state via GitHub, requires the current branch to match configured full-match patterns, is draft-only, and constrains the base branch to repository policy.",
     {
       repo_path: z.string().min(1),
-      title: z.string(),
-      body: z.string(),
+      title: z.string().optional(),
+      body: z.string().optional(),
       base: z.string().min(1).optional(),
+      fill: z.boolean().optional(),
     },
-    async ({ repo_path, title, body, base }) => {
+    async ({ repo_path, title, body, base, fill }) => {
       const repo = await resolveAllowedRepo(config, repo_path);
       const branch = await requireAllowedBranch(repo);
-      const result = await ghPrCreateDraft(repo, branch, { title, body, base });
+      const result = await ghPrCreateDraft(repo, branch, { title, body, base, fill });
 
       return {
         content: [

--- a/src/tools/ghPrCreateDraft.ts
+++ b/src/tools/ghPrCreateDraft.ts
@@ -16,15 +16,14 @@ export type GhPrCreateDraftResult = {
 export async function ghPrCreateDraft(
   repo: RepoPolicy,
   headBranch: string,
-  input: { title?: string; body?: string; base?: string; fill?: boolean },
+  input: { title: string; body: string; base?: string },
 ): Promise<GhPrCreateDraftResult> {
   if (!repo.allowDraftPrs) {
     throw new DraftPrsDisabledError(repo.canonicalPath);
   }
 
-  const fill = input.fill ?? false;
-  const title = input.title?.trim();
-  if (!fill && !title) {
+  const title = input.title.trim();
+  if (!title) {
     throw new EmptyPullRequestTitleError();
   }
 
@@ -33,7 +32,6 @@ export async function ghPrCreateDraft(
   const base = resolveBaseBranch(repo.canonicalPath, configuredBase, requestedBase);
   const url = await createDraftPullRequest(repo.canonicalPath, {
     base,
-    fill,
     title,
     body: input.body,
   });

--- a/src/tools/ghPrCreateDraft.ts
+++ b/src/tools/ghPrCreateDraft.ts
@@ -1,0 +1,81 @@
+import {
+  DraftPrsDisabledError,
+  EmptyPullRequestTitleError,
+  PullRequestBaseBranchError,
+  PullRequestUrlParseError,
+} from "../errors.js";
+import { createDraftPullRequest } from "../exec/gh.js";
+import type { RepoPolicy } from "../types/config.js";
+
+export type GhPrCreateDraftResult = {
+  url: string;
+  base: string;
+  head: string;
+};
+
+export async function ghPrCreateDraft(
+  repo: RepoPolicy,
+  headBranch: string,
+  input: { title: string; body: string; base?: string },
+): Promise<GhPrCreateDraftResult> {
+  if (!repo.allowDraftPrs) {
+    throw new DraftPrsDisabledError(repo.canonicalPath);
+  }
+
+  const title = input.title.trim();
+  if (!title) {
+    throw new EmptyPullRequestTitleError();
+  }
+
+  const requestedBase = input.base?.trim();
+  const configuredBase = repo.defaultPrBase;
+  const base = resolveBaseBranch(repo.canonicalPath, configuredBase, requestedBase);
+  const url = await createDraftPullRequest(repo.canonicalPath, {
+    base,
+    title,
+    body: input.body,
+  });
+
+  if (!looksLikeUrl(url)) {
+    throw new PullRequestUrlParseError(url);
+  }
+
+  return {
+    url,
+    base,
+    head: headBranch,
+  };
+}
+
+function resolveBaseBranch(
+  repoPath: string,
+  configuredBase: string | undefined,
+  requestedBase: string | undefined,
+): string {
+  if (configuredBase && requestedBase && configuredBase !== requestedBase) {
+    throw new PullRequestBaseBranchError(
+      `pull request base '${requestedBase}' does not match configured default base '${configuredBase}' for repository '${repoPath}'`,
+    );
+  }
+
+  if (configuredBase) {
+    return configuredBase;
+  }
+
+  if (!requestedBase) {
+    throw new PullRequestBaseBranchError(
+      `pull request base must be provided when repository '${repoPath}' does not define a default PR base branch`,
+    );
+  }
+
+  return requestedBase;
+}
+
+function looksLikeUrl(value: string): boolean {
+  try {
+    const url = new URL(value);
+    return url.protocol === "https:" || url.protocol === "http:";
+  } catch {
+    return false;
+  }
+}

--- a/src/tools/ghPrCreateDraft.ts
+++ b/src/tools/ghPrCreateDraft.ts
@@ -16,14 +16,15 @@ export type GhPrCreateDraftResult = {
 export async function ghPrCreateDraft(
   repo: RepoPolicy,
   headBranch: string,
-  input: { title: string; body: string; base?: string },
+  input: { title?: string; body?: string; base?: string; fill?: boolean },
 ): Promise<GhPrCreateDraftResult> {
   if (!repo.allowDraftPrs) {
     throw new DraftPrsDisabledError(repo.canonicalPath);
   }
 
-  const title = input.title.trim();
-  if (!title) {
+  const fill = input.fill ?? false;
+  const title = input.title?.trim();
+  if (!fill && !title) {
     throw new EmptyPullRequestTitleError();
   }
 
@@ -32,6 +33,7 @@ export async function ghPrCreateDraft(
   const base = resolveBaseBranch(repo.canonicalPath, configuredBase, requestedBase);
   const url = await createDraftPullRequest(repo.canonicalPath, {
     base,
+    fill,
     title,
     body: input.body,
   });

--- a/tests/ghArgs.test.ts
+++ b/tests/ghArgs.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+
+import { ghPrCreateDraftArgs } from "../src/exec/gh.js";
+
+describe("gh argument builders", () => {
+  it("builds constrained gh draft PR arguments", () => {
+    expect(ghPrCreateDraftArgs("main", "Add feature", "Body")).toEqual([
+      "pr",
+      "create",
+      "--draft",
+      "--base",
+      "main",
+      "--title",
+      "Add feature",
+      "--body",
+      "Body",
+    ]);
+  });
+});

--- a/tests/ghArgs.test.ts
+++ b/tests/ghArgs.test.ts
@@ -4,7 +4,7 @@ import { ghPrCreateDraftArgs } from "../src/exec/gh.js";
 
 describe("gh argument builders", () => {
   it("builds constrained gh draft PR arguments", () => {
-    expect(ghPrCreateDraftArgs("main", "Add feature", "Body")).toEqual([
+    expect(ghPrCreateDraftArgs({ base: "main", title: "Add feature", body: "Body" })).toEqual([
       "pr",
       "create",
       "--draft",
@@ -14,6 +14,17 @@ describe("gh argument builders", () => {
       "Add feature",
       "--body",
       "Body",
+    ]);
+  });
+
+  it("builds constrained gh draft PR arguments with fill", () => {
+    expect(ghPrCreateDraftArgs({ base: "main", fill: true })).toEqual([
+      "pr",
+      "create",
+      "--draft",
+      "--base",
+      "main",
+      "--fill",
     ]);
   });
 });

--- a/tests/ghArgs.test.ts
+++ b/tests/ghArgs.test.ts
@@ -4,7 +4,7 @@ import { ghPrCreateDraftArgs } from "../src/exec/gh.js";
 
 describe("gh argument builders", () => {
   it("builds constrained gh draft PR arguments", () => {
-    expect(ghPrCreateDraftArgs({ base: "main", title: "Add feature", body: "Body" })).toEqual([
+    expect(ghPrCreateDraftArgs("main", "Add feature", "Body")).toEqual([
       "pr",
       "create",
       "--draft",
@@ -14,17 +14,6 @@ describe("gh argument builders", () => {
       "Add feature",
       "--body",
       "Body",
-    ]);
-  });
-
-  it("builds constrained gh draft PR arguments with fill", () => {
-    expect(ghPrCreateDraftArgs({ base: "main", fill: true })).toEqual([
-      "pr",
-      "create",
-      "--draft",
-      "--base",
-      "main",
-      "--fill",
     ]);
   });
 });

--- a/tests/ghPrCreateDraft.test.ts
+++ b/tests/ghPrCreateDraft.test.ts
@@ -1,0 +1,137 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  DraftPrsDisabledError,
+  EmptyPullRequestTitleError,
+  PullRequestBaseBranchError,
+  PullRequestUrlParseError,
+} from "../src/errors.js";
+import type { RepoPolicy } from "../src/types/config.js";
+import { ghPrCreateDraft } from "../src/tools/ghPrCreateDraft.js";
+
+const { createDraftPullRequest } = vi.hoisted(() => ({
+  createDraftPullRequest: vi.fn(),
+}));
+
+vi.mock("../src/exec/gh.js", () => ({
+  createDraftPullRequest,
+  ghPrCreateDraftArgs: vi.fn(),
+}));
+
+const repo: RepoPolicy = {
+  path: "/tmp/repo",
+  canonicalPath: "/tmp/repo",
+  allowedBranchPatterns: [/^dm\/.*$/],
+  defaultRemote: "origin",
+  defaultPrBase: "main",
+  allowDraftPrs: true,
+};
+
+afterEach(() => {
+  createDraftPullRequest.mockReset();
+});
+
+describe("ghPrCreateDraft", () => {
+  it("creates a draft PR using the configured default base", async () => {
+    createDraftPullRequest.mockResolvedValue("https://github.com/example/repo/pull/123");
+
+    const result = await ghPrCreateDraft(repo, "dm/gh-pr-create-draft-v2", {
+      title: "Add draft PR tool",
+      body: "Implements gh_pr_create_draft",
+    });
+
+    expect(createDraftPullRequest).toHaveBeenCalledWith("/tmp/repo", {
+      base: "main",
+      title: "Add draft PR tool",
+      body: "Implements gh_pr_create_draft",
+    });
+    expect(result).toEqual({
+      url: "https://github.com/example/repo/pull/123",
+      base: "main",
+      head: "dm/gh-pr-create-draft-v2",
+    });
+  });
+
+  it("allows an explicit base when no configured default exists", async () => {
+    createDraftPullRequest.mockResolvedValue("https://github.com/example/repo/pull/124");
+
+    const result = await ghPrCreateDraft(
+      {
+        ...repo,
+        defaultPrBase: undefined,
+      },
+      "dm/gh-pr-create-draft-v2",
+      {
+        title: "Add draft PR tool",
+        body: "",
+        base: "main",
+      },
+    );
+
+    expect(result.base).toBe("main");
+    expect(createDraftPullRequest).toHaveBeenCalledWith("/tmp/repo", {
+      base: "main",
+      title: "Add draft PR tool",
+      body: "",
+    });
+  });
+
+  it("rejects disabled draft PRs", async () => {
+    await expect(
+      ghPrCreateDraft(
+        {
+          ...repo,
+          allowDraftPrs: false,
+        },
+        "dm/gh-pr-create-draft-v2",
+        { title: "Add draft PR tool", body: "" },
+      ),
+    ).rejects.toBeInstanceOf(DraftPrsDisabledError);
+  });
+
+  it("rejects empty titles", async () => {
+    await expect(
+      ghPrCreateDraft(repo, "dm/gh-pr-create-draft-v2", {
+        title: "   ",
+        body: "",
+      }),
+    ).rejects.toBeInstanceOf(EmptyPullRequestTitleError);
+  });
+
+  it("rejects explicit bases that conflict with configuration", async () => {
+    await expect(
+      ghPrCreateDraft(repo, "dm/gh-pr-create-draft-v2", {
+        title: "Add draft PR tool",
+        body: "",
+        base: "release",
+      }),
+    ).rejects.toBeInstanceOf(PullRequestBaseBranchError);
+  });
+
+  it("rejects omitted bases when no configured default exists", async () => {
+    await expect(
+      ghPrCreateDraft(
+        {
+          ...repo,
+          defaultPrBase: undefined,
+        },
+        "dm/gh-pr-create-draft-v2",
+        {
+          title: "Add draft PR tool",
+          body: "",
+        },
+      ),
+    ).rejects.toBeInstanceOf(PullRequestBaseBranchError);
+  });
+
+  it("rejects gh output that is not a PR URL", async () => {
+    createDraftPullRequest.mockResolvedValue("created pull request");
+
+    await expect(
+      ghPrCreateDraft(repo, "dm/gh-pr-create-draft-v2", {
+        title: "Add draft PR tool",
+        body: "",
+      }),
+    ).rejects.toBeInstanceOf(PullRequestUrlParseError);
+  });
+});

--- a/tests/ghPrCreateDraft.test.ts
+++ b/tests/ghPrCreateDraft.test.ts
@@ -42,6 +42,7 @@ describe("ghPrCreateDraft", () => {
 
     expect(createDraftPullRequest).toHaveBeenCalledWith("/tmp/repo", {
       base: "main",
+      fill: false,
       title: "Add draft PR tool",
       body: "Implements gh_pr_create_draft",
     });
@@ -71,8 +72,42 @@ describe("ghPrCreateDraft", () => {
     expect(result.base).toBe("main");
     expect(createDraftPullRequest).toHaveBeenCalledWith("/tmp/repo", {
       base: "main",
+      fill: false,
       title: "Add draft PR tool",
       body: "",
+    });
+  });
+
+  it("allows fill mode without an explicit title", async () => {
+    createDraftPullRequest.mockResolvedValue("https://github.com/example/repo/pull/125");
+
+    const result = await ghPrCreateDraft(repo, "dm/gh-pr-create-draft-v2", {
+      fill: true,
+    });
+
+    expect(createDraftPullRequest).toHaveBeenCalledWith("/tmp/repo", {
+      base: "main",
+      fill: true,
+      title: undefined,
+      body: undefined,
+    });
+    expect(result.url).toBe("https://github.com/example/repo/pull/125");
+  });
+
+  it("allows fill mode with title and body overrides", async () => {
+    createDraftPullRequest.mockResolvedValue("https://github.com/example/repo/pull/126");
+
+    await ghPrCreateDraft(repo, "dm/gh-pr-create-draft-v2", {
+      fill: true,
+      title: "Override title",
+      body: "Override body",
+    });
+
+    expect(createDraftPullRequest).toHaveBeenCalledWith("/tmp/repo", {
+      base: "main",
+      fill: true,
+      title: "Override title",
+      body: "Override body",
     });
   });
 

--- a/tests/ghPrCreateDraft.test.ts
+++ b/tests/ghPrCreateDraft.test.ts
@@ -42,7 +42,6 @@ describe("ghPrCreateDraft", () => {
 
     expect(createDraftPullRequest).toHaveBeenCalledWith("/tmp/repo", {
       base: "main",
-      fill: false,
       title: "Add draft PR tool",
       body: "Implements gh_pr_create_draft",
     });
@@ -72,42 +71,8 @@ describe("ghPrCreateDraft", () => {
     expect(result.base).toBe("main");
     expect(createDraftPullRequest).toHaveBeenCalledWith("/tmp/repo", {
       base: "main",
-      fill: false,
       title: "Add draft PR tool",
       body: "",
-    });
-  });
-
-  it("allows fill mode without an explicit title", async () => {
-    createDraftPullRequest.mockResolvedValue("https://github.com/example/repo/pull/125");
-
-    const result = await ghPrCreateDraft(repo, "dm/gh-pr-create-draft-v2", {
-      fill: true,
-    });
-
-    expect(createDraftPullRequest).toHaveBeenCalledWith("/tmp/repo", {
-      base: "main",
-      fill: true,
-      title: undefined,
-      body: undefined,
-    });
-    expect(result.url).toBe("https://github.com/example/repo/pull/125");
-  });
-
-  it("allows fill mode with title and body overrides", async () => {
-    createDraftPullRequest.mockResolvedValue("https://github.com/example/repo/pull/126");
-
-    await ghPrCreateDraft(repo, "dm/gh-pr-create-draft-v2", {
-      fill: true,
-      title: "Override title",
-      body: "Override body",
-    });
-
-    expect(createDraftPullRequest).toHaveBeenCalledWith("/tmp/repo", {
-      base: "main",
-      fill: true,
-      title: "Override title",
-      body: "Override body",
     });
   });
 


### PR DESCRIPTION
Why
This repository already supports the Git-side workflow for staging, committing, pushing, creating branches, and switching between clean branches through constrained MCP tools. Draft PR creation was the remaining GitHub-facing step needed to complete that workflow.

This change adds a narrow `gh_pr_create_draft` tool backed by `gh pr create --draft`, with policy checks around draft-PR enablement, title validation, base-branch selection, and URL parsing.

Impact
Codex can now create draft pull requests through the MCP server on authorized branches, which closes the loop on the intended Git/GitHub flow.

The main risk is branch-policy mismatch in local config: if the active branch does not match the configured allowlist, the tool will still deny the PR creation call even though the implementation exists.