### PR TITLE
Add constrained git_fetch MCP tool

### DIFF
--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -58,6 +58,7 @@ src/
     gitStatus.ts
     gitAdd.ts
     gitCommit.ts
+    gitFetch.ts
     gitPush.ts
     gitBranchCreateAndSwitch.ts
     gitBranchSwitch.ts
@@ -622,6 +623,7 @@ Implement in phases to reduce risk.
 - `git_status`
 - `git_add`
 - `git_commit`
+- `git_fetch`
 - `git_push`
 - `git_branch_create_and_switch`
 - `git_branch_switch`
@@ -637,18 +639,16 @@ The core constrained Git/GitHub workflow is now implemented end-to-end.
   Today most `gh` failures surface through the generic command-execution path. A follow-up could detect common authentication and authorization cases and return more specific policy-oriented errors.
 - docs and describe polish
   The server descriptions and top-level docs now match the current tool surface, but could be improved further with clearer workflow examples and richer server-level guidance.
-- optional constrained `git_fetch` support if upstream refresh through MCP proves useful
-  If fetching remote-tracking refs keeps showing up as a workflow gap, add a constrained fetch helper fixed to the configured remote and plain branch names only.
 
 ### Suggested Workflow
 
 For this repository and in general, the intended end-to-end workflow is:
 
 1. create and switch to a new branch from the detected upstream base
-3. do planning and coding work
-4. commit through the constrained commit tool
-5. push the current branch through the constrained push tool
-6. create a draft PR through the constrained GitHub tool
+2. do planning and coding work
+3. commit through the constrained commit tool
+4. push the current branch through the constrained push tool
+5. create a draft PR through the constrained GitHub tool
 
 ## Deferred Work
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Current tool surface:
 - `git_status`
 - `git_add`
 - `git_commit`
+- `git_fetch`
 - `git_push`
 - `git_branch_create_and_switch`
 - `git_branch_switch`
@@ -46,6 +47,7 @@ Notes:
 - `path` must be an absolute path or start with `~/`
 - branch patterns are full-match regexes against the current branch name
 - `git_add`, `git_commit`, `git_push`, and `gh_pr_create_draft` require the current branch to match one of the configured patterns
+- `git_fetch` only requires the repository to be allowlisted and fetches from the resolved remote
 - `git_branch_create_and_switch` and `git_branch_switch` require a clean worktree but do not require the current branch to match `allowed_branch_patterns`
 - branch creation and PR base detection use runtime inference rather than `default_pr_base`
 - remote selection defaults to the current branch's remote when available, then `origin`, unless `default_remote` is explicitly configured
@@ -115,6 +117,7 @@ Once registered, Codex should be able to use:
 - `git_status` for an allowlisted repository
 - `git_add` for repository-relative paths inside an allowlisted repository
 - `git_commit` with a normal commit message on an allowed branch
+- `git_fetch` to fetch a plain branch name from the detected remote, defaulting to `main`
 - `git_branch_create_and_switch` to create a local branch from an explicit or detected upstream base and switch to it
 - `git_branch_switch` to switch to an existing local branch when the worktree is clean
 - `git_push` to push the current branch to the detected remote
@@ -127,6 +130,7 @@ Current behavior:
 - `git_commit` rejects empty commits
 - `git_branch_create_and_switch` detects the remote at runtime, uses the explicit base branch when provided or detects one otherwise, fetches that base, creates the local branch, and switches to it
 - `git_branch_switch` only switches to an explicit existing local branch and rejects dirty worktrees
+- `git_fetch` only fetches `git fetch <resolved-remote> <branch>` and defaults the branch to `main`
 - `git_push` only pushes `HEAD` to `refs/heads/<current-branch>` on the resolved remote
 - `git_push` does not allow arbitrary refspecs or force-like behavior
 - `gh_pr_create_draft` is draft-only and uses either the explicit `base` input or the detected default branch
@@ -157,5 +161,4 @@ repositories:
 ## Current Limitations
 
 - output is returned as JSON text content rather than richer structured MCP content
-- there is no general-purpose fetch helper yet
 - the current setup assumes local `git` is available

--- a/src/server.ts
+++ b/src/server.ts
@@ -9,6 +9,7 @@ import { gitBranchCreateAndSwitch } from "./tools/gitBranchCreateAndSwitch.js";
 import { gitBranchSwitch } from "./tools/gitBranchSwitch.js";
 import { ghPrCreateDraft } from "./tools/ghPrCreateDraft.js";
 import { gitCommit } from "./tools/gitCommit.js";
+import { gitFetch } from "./tools/gitFetch.js";
 import { gitPush } from "./tools/gitPush.js";
 import { getGitStatus } from "./tools/gitStatus.js";
 
@@ -118,6 +119,28 @@ export function createServer(config: Config): McpServer {
     async ({ repo_path, branch }) => {
       const repo = await resolveAllowedRepo(config, repo_path);
       const result = await gitBranchSwitch(repo, branch);
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(result, null, 2),
+          },
+        ],
+      };
+    },
+  );
+
+  server.tool(
+    "git_fetch",
+    "Fetch a plain branch name from the detected remote for an allowlisted repository. This tool refreshes remote-tracking refs, defaults to 'main' when no branch is provided, and does not allow arbitrary fetch arguments.",
+    {
+      repo_path: z.string().min(1),
+      branch: z.string().optional(),
+    },
+    async ({ repo_path, branch }) => {
+      const repo = await resolveAllowedRepo(config, repo_path);
+      const result = await gitFetch(repo, { branch });
 
       return {
         content: [

--- a/src/tools/gitFetch.ts
+++ b/src/tools/gitFetch.ts
@@ -1,0 +1,58 @@
+import { PathValidationError } from "../errors.js";
+import { fetchBranch } from "../exec/git.js";
+import type { RepoPolicy } from "../types/config.js";
+import { resolveRepoRemote } from "./runtimeDefaults.js";
+
+export type GitFetchResult = {
+  remote: string;
+  branch: string;
+};
+
+export async function gitFetch(repo: RepoPolicy, input: { branch?: string }): Promise<GitFetchResult> {
+  const branch = normalizeFetchBranch(input.branch);
+  const remote = await resolveRepoRemote(repo);
+
+  await fetchBranch(repo.canonicalPath, remote, branch);
+
+  return {
+    remote,
+    branch,
+  };
+}
+
+function normalizeFetchBranch(branch: string | undefined): string {
+  const normalized = branch?.trim() ?? "";
+  if (!normalized) {
+    return "main";
+  }
+
+  if (!isPlainBranchName(normalized)) {
+    throw new PathValidationError(`branch '${normalized}' must be a plain branch name`);
+  }
+
+  return normalized;
+}
+
+function isPlainBranchName(branch: string): boolean {
+  if (branch.startsWith("-")) {
+    return false;
+  }
+
+  if (branch.length === 0) {
+    return false;
+  }
+
+  if (branch.startsWith("/") || branch.endsWith("/")) {
+    return false;
+  }
+
+  if (branch.startsWith("refs/")) {
+    return false;
+  }
+
+  if (branch.includes("//")) {
+    return false;
+  }
+
+  return /^[A-Za-z0-9._/-]+$/.test(branch);
+}

--- a/tests/gitFetch.test.ts
+++ b/tests/gitFetch.test.ts
@@ -1,0 +1,100 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { PathValidationError } from "../src/errors.js";
+import { getCurrentBranch } from "../src/exec/git.js";
+import { runCommand } from "../src/exec/run.js";
+import { gitAdd } from "../src/tools/gitAdd.js";
+import { gitCommit } from "../src/tools/gitCommit.js";
+import { gitFetch } from "../src/tools/gitFetch.js";
+import { gitPush } from "../src/tools/gitPush.js";
+import { createTempBareGitRepo, createTempGitRepo } from "./helpers.js";
+
+const tempPaths: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempPaths.splice(0).map((tempPath) => fs.rm(tempPath, { force: true, recursive: true })));
+});
+
+describe("gitFetch", () => {
+  it("fetches main when no branch is provided", async () => {
+    const { repoDir, repo } = await createTempGitRepo();
+    const remoteDir = await createTempBareGitRepo();
+    const updaterDir = await fs.mkdtemp(path.join(path.dirname(repoDir), "git-mcp-updater-"));
+    tempPaths.push(repoDir, remoteDir, updaterDir);
+
+    await runCommand({ cwd: repoDir, command: "git", argv: ["remote", "add", "origin", remoteDir] });
+    await fs.writeFile(path.join(repoDir, "README.md"), "hello\n", "utf8");
+    await gitAdd(repo, ["README.md"]);
+    await gitCommit(repo, "add readme");
+    await gitPush(repo, "main");
+    await runCommand({ cwd: remoteDir, command: "git", argv: ["symbolic-ref", "HEAD", "refs/heads/main"] });
+
+    await runCommand({ cwd: updaterDir, command: "git", argv: ["clone", remoteDir, "."] });
+    await runCommand({ cwd: updaterDir, command: "git", argv: ["config", "user.name", "Codex Test"] });
+    await runCommand({ cwd: updaterDir, command: "git", argv: ["config", "user.email", "codex@example.com"] });
+    await fs.writeFile(path.join(updaterDir, "CHANGELOG.md"), "update\n", "utf8");
+    await runCommand({ cwd: updaterDir, command: "git", argv: ["add", "CHANGELOG.md"] });
+    await runCommand({ cwd: updaterDir, command: "git", argv: ["commit", "-m", "remote update"] });
+    await runCommand({ cwd: updaterDir, command: "git", argv: ["push", "origin", "HEAD:refs/heads/main"] });
+
+    const result = await gitFetch(repo, {});
+    const remoteMain = await runCommand({
+      cwd: repoDir,
+      command: "git",
+      argv: ["rev-parse", "--verify", "refs/remotes/origin/main"],
+    });
+    const remoteMainCommit = await runCommand({
+      cwd: updaterDir,
+      command: "git",
+      argv: ["rev-parse", "--verify", "HEAD"],
+    });
+
+    expect(result).toEqual({ remote: "origin", branch: "main" });
+    expect(remoteMain.stdout.trim()).toBe(remoteMainCommit.stdout.trim());
+  });
+
+  it("fetches an explicit branch from the resolved remote", async () => {
+    const { repoDir, repo } = await createTempGitRepo();
+    const remoteDir = await createTempBareGitRepo();
+    tempPaths.push(repoDir, remoteDir);
+
+    await runCommand({ cwd: repoDir, command: "git", argv: ["remote", "add", "origin", remoteDir] });
+    await fs.writeFile(path.join(repoDir, "README.md"), "hello\n", "utf8");
+    await gitAdd(repo, ["README.md"]);
+    await gitCommit(repo, "add readme");
+    await gitPush(repo, "main");
+    await runCommand({ cwd: remoteDir, command: "git", argv: ["symbolic-ref", "HEAD", "refs/heads/main"] });
+
+    await runCommand({ cwd: repoDir, command: "git", argv: ["checkout", "-b", "release"] });
+    await expect(getCurrentBranch(repoDir)).resolves.toBe("release");
+    await fs.writeFile(path.join(repoDir, "RELEASE.md"), "release\n", "utf8");
+    await gitAdd(repo, ["RELEASE.md"]);
+    await gitCommit(repo, "add release notes");
+    await gitPush(repo, "release");
+    await runCommand({ cwd: repoDir, command: "git", argv: ["checkout", "main"] });
+
+    const result = await gitFetch(repo, { branch: "release" });
+    const remoteRelease = await runCommand({
+      cwd: repoDir,
+      command: "git",
+      argv: ["rev-parse", "--verify", "refs/remotes/origin/release"],
+    });
+
+    expect(result).toEqual({ remote: "origin", branch: "release" });
+    expect(remoteRelease.stdout.trim()).toMatch(/^[0-9a-f]{40}$/);
+  });
+
+  it("rejects non-plain branch names", async () => {
+    const { repoDir, repo } = await createTempGitRepo();
+    const remoteDir = await createTempBareGitRepo();
+    tempPaths.push(repoDir, remoteDir);
+
+    await runCommand({ cwd: repoDir, command: "git", argv: ["remote", "add", "origin", remoteDir] });
+
+    await expect(gitFetch(repo, { branch: "refs/heads/main" })).rejects.toBeInstanceOf(PathValidationError);
+    await expect(gitFetch(repo, { branch: "main --tags" })).rejects.toBeInstanceOf(PathValidationError);
+  });
+});


### PR DESCRIPTION
## Why
Codex can already stage, commit, push, branch, and open draft PRs through the constrained MCP surface, but it still has no way to refresh remote-tracking refs without falling back to shell Git. That leaves a gap in the workflow when the agent needs an upstream branch update before branch creation or other remote-aware operations.

This change adds a narrow `git_fetch` tool instead of a general-purpose fetch wrapper. It stays fixed to the resolved repository remote, accepts only a plain branch name, and defaults to `main` when no branch is provided.

## Impact
Codex can now fetch an upstream branch through MCP without arbitrary fetch flags or refspecs. That keeps the tool surface aligned with the server's constrained-git design and removes one of the remaining workflow gaps called out in `IMPLEMENTATION.md`.

The main risk is choosing a default branch name that does not exist in every repository. In this repo that matches the requested behavior, but callers still need to pass an explicit branch when the remote default is not `main`.