### PR TITLE
Move suggested workflow guidance into AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,14 @@
+# Agents
+
+## Suggested Workflow
+
+For this repository (and in general), the intended end-to-end workflow is:
+
+1. create and switch to a new branch from the detected upstream base
+2. do planning and coding work
+3. commit changes (prefer smaller, targeted commits)
+4. push the current branch
+5. create a draft PR
+6. address PR review comments and iterate as needed, preferably one comment at a time or grouped by theme
+
+The Git and GitHub operations for the steps above must be performed using the `git_unleash` MCP.

--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -642,13 +642,7 @@ The core constrained Git/GitHub workflow is now implemented end-to-end.
 
 ### Suggested Workflow
 
-For this repository and in general, the intended end-to-end workflow is:
-
-1. create and switch to a new branch from the detected upstream base
-2. do planning and coding work
-3. commit through the constrained commit tool
-4. push the current branch through the constrained push tool
-5. create a draft PR through the constrained GitHub tool
+See [AGENTS.md](AGENTS.md) for the suggested workflow.
 
 ## Deferred Work
 


### PR DESCRIPTION
## Why

The suggested workflow is operational guidance for working in this repository, not part of the implementation plan itself. Keeping that guidance in `AGENTS.md` makes the repo workflow easier to find and keeps `IMPLEMENTATION.md` focused on implementation details.

This change also fixes the remaining reference in `IMPLEMENTATION.md` so it points to `AGENTS.md` with a relative link.

## Impact

The workflow guidance now lives in one place, which should reduce duplication and make future edits simpler. The implementation document stays shorter and more focused.

The main risk is low and limited to documentation discoverability, but the relative link in `IMPLEMENTATION.md` keeps the connection explicit.