### PR TITLE
git: polish workflow and MCP docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,8 +1,8 @@
 # Agents
 
-## Suggested Workflow
+## Required Workflow
 
-For this repository (and in general), the intended end-to-end workflow is:
+For this repository, the following end-to-end workflow is required for repository changes:
 
 1. create and switch to a new branch from the detected upstream base
 2. do planning and coding work
@@ -10,5 +10,7 @@ For this repository (and in general), the intended end-to-end workflow is:
 4. push the current branch
 5. create a draft PR
 6. address PR review comments and iterate as needed, preferably one comment at a time or grouped by theme
+
+Do not begin planning edits or making repository changes on the current branch before step 1 is complete.
 
 The Git and GitHub operations for the steps above must be performed using the `git_unleash` MCP.

--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -637,12 +637,12 @@ The core constrained Git/GitHub workflow is now implemented end-to-end.
   The current server returns JSON serialized into MCP text content. A useful follow-up would be returning cleaner structured fields for status, branch operations, and PR creation results so clients do not need to parse text payloads.
 - better GitHub/authentication failure mapping
   Today most `gh` failures surface through the generic command-execution path. A follow-up could detect common authentication and authorization cases and return more specific policy-oriented errors.
-- docs and describe polish
-  The server descriptions and top-level docs now match the current tool surface, but could be improved further with clearer workflow examples and richer server-level guidance.
+- richer server-level guidance
+  The tool descriptions and top-level docs now cover the implemented workflow and constraints, but the server could still expose a stronger top-level description of the trust boundary and authorized repository scope if MCP clients start surfacing that metadata more prominently.
 
-### Suggested Workflow
+### Required Workflow
 
-See [AGENTS.md](AGENTS.md) for the suggested workflow.
+See [AGENTS.md](AGENTS.md) for the required workflow.
 
 ## Deferred Work
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # codex-git-unleash-mcp
 
-Local MCP server for a narrow set of Git operations that Codex can call without repeated shell approval prompts.
+Local MCP server for a narrow, policy-constrained set of Git and GitHub operations that Codex can call without repeated shell approval prompts.
+
+It exists to handle a small approved workflow through MCP tools instead of ad hoc shell access: inspect repository state, stage and commit changes, fetch and push the current branch, create or switch local branches in a constrained way, and open draft pull requests.
 
 Current tool surface:
 
@@ -12,6 +14,8 @@ Current tool surface:
 - `git_branch_create_and_switch`
 - `git_branch_switch`
 - `gh_pr_create_draft`
+
+The server is intentionally not a generic `git` or `gh` proxy. Inputs are structured, commands are fixed, and unsupported operations are denied by default.
 
 ## Prerequisites
 
@@ -49,9 +53,22 @@ Notes:
 - `git_add`, `git_commit`, `git_push`, and `gh_pr_create_draft` require the current branch to match one of the configured patterns
 - `git_fetch` only requires the repository to be allowlisted and fetches from the resolved remote
 - `git_branch_create_and_switch` and `git_branch_switch` require a clean worktree but do not require the current branch to match `allowed_branch_patterns`
-- branch creation and PR base detection use runtime inference rather than `default_pr_base`
-- remote selection defaults to the current branch's remote when available, then `origin`, unless `default_remote` is explicitly configured
+- remote resolution prefers configured `default_remote` when present and valid, then the current branch's remote, then `origin`
+- branch creation and PR base resolution prefer the remote HEAD branch and fall back to GitHub default-branch detection when needed
 - `git_status` only requires the repository to be allowlisted
+
+## Workflow Summary
+
+The intended happy path is:
+
+1. Call `git_status` to inspect the allowlisted repository.
+2. Call `git_branch_create_and_switch` to branch from an explicit or detected upstream base when you need a new local branch.
+3. Call `git_add` with explicit repository-relative paths.
+4. Call `git_commit` with a normal commit message.
+5. Call `git_push` to push the current branch to the resolved remote.
+6. Call `gh_pr_create_draft` to open a draft PR against an explicit base or the detected default base branch.
+
+Each step stays inside a fixed policy boundary. There is no arbitrary checkout, no arbitrary push refspec, no amend flow, and no non-draft PR creation.
 
 ## Run Locally
 
@@ -128,13 +145,23 @@ Current behavior:
 - `git_add` rejects absolute paths and repository-escaping paths like `../x`
 - `git_commit` rejects empty commit messages
 - `git_commit` rejects empty commits
-- `git_branch_create_and_switch` detects the remote at runtime, uses the explicit base branch when provided or detects one otherwise, fetches that base, creates the local branch, and switches to it
+- `git_branch_create_and_switch` resolves the remote at runtime, uses the explicit base branch when provided or detects one otherwise, fetches that base, creates the local branch, and switches to it
 - `git_branch_switch` only switches to an explicit existing local branch and rejects dirty worktrees
 - `git_fetch` only fetches `git fetch <resolved-remote> <branch>` and defaults the branch to `main`
 - `git_push` only pushes `HEAD` to `refs/heads/<current-branch>` on the resolved remote
 - `git_push` does not allow arbitrary refspecs or force-like behavior
-- `gh_pr_create_draft` is draft-only and uses either the explicit `base` input or the detected default branch
+- `gh_pr_create_draft` is draft-only, requires a non-empty title, and uses either the explicit `base` input or the detected default branch
 - mutating tools reject detached HEAD
+
+## Remote And Base Resolution
+
+Some operations resolve defaults at runtime instead of requiring everything to be pinned in config.
+
+- `git_fetch`, `git_push`, `git_branch_create_and_switch`, and `gh_pr_create_draft` resolve the remote by preferring configured `default_remote`, then the current branch remote, then `origin`
+- `git_branch_create_and_switch` and `gh_pr_create_draft` resolve the base branch by preferring the remote HEAD branch and falling back to the GitHub repository default branch
+- `git_fetch` keeps a narrower default and uses `main` when no branch is provided
+
+This keeps the tools constrained while still working across repositories that use different default branches or remotes.
 
 ## Example Config For This Repo
 
@@ -162,3 +189,4 @@ repositories:
 
 - output is returned as JSON text content rather than richer structured MCP content
 - the current setup assumes local `git` is available
+- `gh_pr_create_draft` depends on a working `gh` CLI login for the target repository

--- a/src/server.ts
+++ b/src/server.ts
@@ -15,13 +15,13 @@ import { getGitStatus } from "./tools/gitStatus.js";
 
 export function createServer(config: Config): McpServer {
   const server = new McpServer({
-    name: "git-github-approval-mcp",
+    name: "codex-git-unleash-mcp",
     version: "0.1.0",
   });
 
   server.tool(
     "git_status",
-    "Show git status for an allowlisted repository. This tool is read-only and does not require branch authorization.",
+    "Show git status for an allowlisted repository. This tool is read-only, returns the current branch and worktree summary, and does not require branch authorization.",
     {
       repo_path: z.string().min(1),
     },
@@ -42,7 +42,7 @@ export function createServer(config: Config): McpServer {
 
   server.tool(
     "git_add",
-    "Stage a constrained list of repository-relative paths in an allowlisted repository. This tool mutates repository state and requires the current branch to match configured full-match patterns.",
+    "Stage a constrained list of repository-relative paths in an allowlisted repository. This tool mutates repository state, requires the current branch to match configured full-match patterns, and rejects absolute or repository-escaping paths.",
     {
       repo_path: z.string().min(1),
       paths: z.array(z.string().min(1)).min(1),
@@ -65,7 +65,7 @@ export function createServer(config: Config): McpServer {
 
   server.tool(
     "git_commit",
-    "Create a normal commit in an allowlisted repository. This tool mutates repository state, requires the current branch to match configured full-match patterns, and rejects empty commits.",
+    "Create a normal commit in an allowlisted repository. This tool mutates repository state, requires the current branch to match configured full-match patterns, rejects empty commit messages, and rejects empty commits.",
     {
       repo_path: z.string().min(1),
       message: z.string(),
@@ -88,7 +88,7 @@ export function createServer(config: Config): McpServer {
 
   server.tool(
     "git_branch_create_and_switch",
-    "Create a new local branch from an explicit or detected upstream base branch for an allowlisted repository, then switch to it. This tool requires a clean worktree, infers the remote at runtime, fetches the chosen base branch first, and does not accept arbitrary source refs.",
+    "Create a new local branch from an explicit or detected upstream base branch for an allowlisted repository, then switch to it. This tool requires a clean worktree, resolves the remote at runtime, fetches the chosen base branch first, and does not accept arbitrary source refs or detached targets.",
     {
       repo_path: z.string().min(1),
       new_branch: z.string(),
@@ -133,7 +133,7 @@ export function createServer(config: Config): McpServer {
 
   server.tool(
     "git_fetch",
-    "Fetch a plain branch name from the detected remote for an allowlisted repository. This tool refreshes remote-tracking refs, defaults to 'main' when no branch is provided, and does not allow arbitrary fetch arguments.",
+    "Fetch a plain branch name from the detected remote for an allowlisted repository. This tool refreshes remote-tracking refs, defaults to 'main' when no branch is provided, and does not allow arbitrary fetch arguments or refspecs.",
     {
       repo_path: z.string().min(1),
       branch: z.string().optional(),
@@ -155,7 +155,7 @@ export function createServer(config: Config): McpServer {
 
   server.tool(
     "git_push",
-    "Push the current branch to the detected remote for an allowlisted repository. This tool mutates repository state, requires the current branch to match configured full-match patterns, and does not allow arbitrary refspecs or force-like behavior.",
+    "Push the current branch to the detected remote for an allowlisted repository. This tool mutates repository state, requires the current branch to match configured full-match patterns, and does not allow arbitrary refspecs, force-like behavior, or pushing unrelated branches.",
     {
       repo_path: z.string().min(1),
     },
@@ -177,7 +177,7 @@ export function createServer(config: Config): McpServer {
 
   server.tool(
     "gh_pr_create_draft",
-    "Create a draft pull request for the current branch in an allowlisted repository. This tool mutates repository state via GitHub, requires the current branch to match configured full-match patterns, is draft-only, and uses either an explicit base or a runtime-detected default branch.",
+    "Create a draft pull request for the current branch in an allowlisted repository. This tool mutates repository state via GitHub, requires the current branch to match configured full-match patterns, is draft-only, requires a non-empty title, and uses either an explicit base or a runtime-detected default branch.",
     {
       repo_path: z.string().min(1),
       title: z.string(),


### PR DESCRIPTION
## Why
The repository workflow and the user-facing MCP documentation were slightly out of sync with the current implementation. In particular, the local `AGENTS.md` wording made the branch-first flow easy to treat as advisory, and the top-level docs and tool descriptions were missing a clearer explanation of the constrained workflow, runtime resolution behavior, and current tool limits.

This change makes the required branch-first workflow explicit, aligns the implementation notes with that requirement, and tightens the README and MCP tool descriptions so the current behavior is easier to understand without trial and error.

## Impact
The expected positive outcome is clearer repo-local instructions for agents and clearer MCP-facing documentation for users and clients. That should reduce workflow mistakes and make the approved trust boundary more obvious.

The main risk is minor wording churn in docs and descriptions. There is no intended behavior change in the underlying Git or GitHub tool execution paths.