### PR TITLE
docs: trim stale planning sections from design docs

### DIFF
--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -593,30 +593,6 @@ Cover:
 
 Live GitHub integration tests can be deferred until later.
 
-## Rollout Plan
-
-Implement in phases to reduce risk.
-
-### Phase 1
-
-- config loading
-- repository authorization
-- branch authorization
-- `git_status`
-
-### Phase 2
-
-- `git_add`
-- `git_commit`
-- path validation
-- command builder tests
-
-### Phase 3
-
-- `git_push`
-- remote policy enforcement
-- better error mapping
-
 ### Completed Core Workflow
 
 - config loading and authorization
@@ -630,35 +606,3 @@ Implement in phases to reduce risk.
 - `gh_pr_create_draft`
 
 The core constrained Git/GitHub workflow is now implemented end-to-end.
-
-### Next Steps
-
-- richer structured MCP output instead of JSON text blobs
-  The current server returns JSON serialized into MCP text content. A useful follow-up would be returning cleaner structured fields for status, branch operations, and PR creation results so clients do not need to parse text payloads.
-- better GitHub/authentication failure mapping
-  Today most `gh` failures surface through the generic command-execution path. A follow-up could detect common authentication and authorization cases and return more specific policy-oriented errors.
-- richer server-level guidance
-  The tool descriptions and top-level docs now cover the implemented workflow and constraints, but the server could still expose a stronger top-level description of the trust boundary and authorized repository scope if MCP clients start surfacing that metadata more prominently.
-
-### Required Workflow
-
-See [AGENTS.md](AGENTS.md) for the required workflow.
-
-## Deferred Work
-
-Out of scope for the first implementation:
-
-- direct GitHub API client
-- arbitrary GitHub read helpers
-- support for multiple remotes per operation
-- advanced Git pathspec support
-- branch switching
-- configurable commit policy hooks
-- server-managed credential handling
-
-## Open Questions To Revisit After V1
-
-- whether to return richer structured Git status instead of mostly normalized text
-- whether PR base branch input should be restricted to a configured allowlist rather than a single default
-- whether server-level descriptions should enumerate all repositories or keep that implicit
-- whether some read-only GitHub tools are worth adding

--- a/SPEC.md
+++ b/SPEC.md
@@ -294,17 +294,6 @@ Examples:
 
 The server should prefer clear denials over implicit fallback behavior.
 
-## Open Questions
-
-These are not blockers for the spec, but they should be resolved during implementation design:
-
-- exact MCP framework and language choice
-- exact config file path and format
-- whether `git_status` should require branch authorization or only repository authorization
-- whether empty commits should always be denied
-- whether PR creation should infer defaults or require explicit base branch input
-- whether GitHub operations should use `gh`, direct API calls, or a mix
-
 ## Reference
 
 OpenAI Codex protected-path behavior:


### PR DESCRIPTION
## Why
The design docs still included planning and open-question sections that were useful during implementation but now read as stale status/backlog material.

## What changed
- removed obsolete rollout and future-work sections from `IMPLEMENTATION.md`
- removed resolved `Open Questions` from `SPEC.md`
- kept the stable design and behavior documentation intact

## Impact
The docs are shorter and more current, with less ambiguity about what is still planned versus already implemented.

Potential downside: deferred ideas that were previously captured in prose are no longer kept in these docs.