### PR TITLE
Add GitHub Actions test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,8 @@ name: Test
 on:
   pull_request:
   push:
+    branches:
+      - main
 
 jobs:
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,31 @@
+name: Test
+
+on:
+  pull_request:
+  push:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run typecheck
+        run: npm run typecheck
+
+      - name: Run tests
+        run: npm test
+
+      - name: Build
+        run: npm run build

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -8,7 +8,7 @@ import type { RepoPolicy } from "../src/types/config.js";
 export async function createTempGitRepo(): Promise<{ repoDir: string; repo: RepoPolicy }> {
   const repoDir = await fs.mkdtemp(path.join(os.tmpdir(), "git-mcp-repo-"));
 
-  await runCommand({ cwd: repoDir, command: "git", argv: ["init"] });
+  await runCommand({ cwd: repoDir, command: "git", argv: ["init", "--initial-branch=main"] });
   await runCommand({ cwd: repoDir, command: "git", argv: ["config", "user.name", "Codex Test"] });
   await runCommand({ cwd: repoDir, command: "git", argv: ["config", "user.email", "codex@example.com"] });
 


### PR DESCRIPTION
## Why
This repository already defines a clear local validation path with `npm run typecheck`, `npm test`, and `npm run build`, but it does not run those checks automatically in GitHub. Adding a lightweight Actions workflow makes the expected validation path consistent for pushes and pull requests.

## Impact
The repository will now run dependency install, typechecking, tests, and build automatically in GitHub Actions on `push` and `pull_request`. This should catch regressions earlier, with the main tradeoff being the added CI runtime on every branch update and PR.