### PR TITLE
Add auto-approval workflow for owner PRs

### DIFF
--- a/.github/workflows/auto-approve-owner-prs.yml
+++ b/.github/workflows/auto-approve-owner-prs.yml
@@ -1,0 +1,24 @@
+name: Auto-approve owner PRs
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  auto-approve:
+    if: github.event.pull_request.user.login == github.repository_owner && github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Approve PR
+        uses: hmarr/auto-approve-action@v4
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Why
This repository now has GitHub Actions-based CI, and owner-authored pull requests can be streamlined further by automatically applying an approval when the PR is opened by the repository owner and is ready for review. This matches the existing pattern used in `niamster/tgrep`.

## Impact
Non-draft pull requests opened by the repository owner will be auto-approved through a dedicated `pull_request_target` workflow. This reduces manual review friction for owner-authored changes, with the main tradeoff being that approval automation now depends on the workflow guard remaining narrowly scoped to owner and non-draft PRs.