### PR TITLE
docs: replace dm branch examples with user

### DIFF
--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-This document translates [SPEC.md](/Users/dm/projects/codex-git-unleash-mcp/SPEC.md) into a concrete implementation approach.
+This document translates [SPEC.md](./SPEC.md) into a concrete implementation approach.
 
 The goal is to build a local MCP server that exposes a narrow, structured set of Git and GitHub operations that Codex can call without repeated shell approval prompts, while keeping the trust boundary explicit and small.
 
@@ -104,7 +104,7 @@ Initial YAML schema:
 repositories:
   - path: /absolute/path/to/repo
     allowed_branch_patterns:
-      - "^dm/.*$"
+      - "^user/.*$"
       - "^feature/[a-z0-9._-]+$"
     default_remote: origin
     allow_draft_prs: true

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ If you want to branch from `main` but only allow mutations on personal feature b
 repositories:
   - path: ~/projects/codex-git-unleash-mcp
     allowed_branch_patterns:
-      - "^dm/.*$"
+      - "^user/.*$"
       - "^feature/[a-z0-9._-]+$"
 ```
 
@@ -187,7 +187,7 @@ If you want to allow only personal feature branches:
 repositories:
   - path: ~/projects/codex-git-unleash-mcp
     allowed_branch_patterns:
-      - "^dm/.*$"
+      - "^user/.*$"
       - "^feature/[a-z0-9._-]+$"
 ```
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -259,7 +259,7 @@ Example shape:
 repositories:
   - path: /absolute/path/to/repo
     allowed_branch_patterns:
-      - "^dm/.*$"
+      - "^user/.*$"
       - "^feature/[a-z0-9._-]+$"
     allow_draft_prs: true
 ```

--- a/tests/ghPrCreateDraft.test.ts
+++ b/tests/ghPrCreateDraft.test.ts
@@ -29,7 +29,7 @@ vi.mock("../src/tools/runtimeDefaults.js", () => ({
 const repo: RepoPolicy = {
   path: "/tmp/repo",
   canonicalPath: "/tmp/repo",
-  allowedBranchPatterns: [/^dm\/.*$/],
+  allowedBranchPatterns: [/^user\/.*$/],
   allowDraftPrs: true,
 };
 
@@ -45,7 +45,7 @@ describe("ghPrCreateDraft", () => {
     resolveRepoRemote.mockResolvedValue("origin");
     resolveRepoBaseBranch.mockResolvedValue("main");
 
-    const result = await ghPrCreateDraft(repo, "dm/gh-pr-create-draft-v2", {
+    const result = await ghPrCreateDraft(repo, "user/gh-pr-create-draft-v2", {
       title: "Add draft PR tool",
       body: "Implements gh_pr_create_draft",
     });
@@ -58,7 +58,7 @@ describe("ghPrCreateDraft", () => {
     expect(result).toEqual({
       url: "https://github.com/example/repo/pull/123",
       base: "main",
-      head: "dm/gh-pr-create-draft-v2",
+      head: "user/gh-pr-create-draft-v2",
     });
   });
 
@@ -66,7 +66,7 @@ describe("ghPrCreateDraft", () => {
     createDraftPullRequest.mockResolvedValue("https://github.com/example/repo/pull/124");
     resolveRepoRemote.mockResolvedValue("origin");
 
-    const result = await ghPrCreateDraft(repo, "dm/gh-pr-create-draft-v2", {
+    const result = await ghPrCreateDraft(repo, "user/gh-pr-create-draft-v2", {
       title: "Add draft PR tool",
       body: "",
       base: "main",
@@ -88,7 +88,7 @@ describe("ghPrCreateDraft", () => {
           ...repo,
           allowDraftPrs: false,
         },
-        "dm/gh-pr-create-draft-v2",
+        "user/gh-pr-create-draft-v2",
         { title: "Add draft PR tool", body: "" },
       ),
     ).rejects.toBeInstanceOf(DraftPrsDisabledError);
@@ -96,7 +96,7 @@ describe("ghPrCreateDraft", () => {
 
   it("rejects empty titles", async () => {
     await expect(
-      ghPrCreateDraft(repo, "dm/gh-pr-create-draft-v2", {
+      ghPrCreateDraft(repo, "user/gh-pr-create-draft-v2", {
         title: "   ",
         body: "",
       }),
@@ -108,7 +108,7 @@ describe("ghPrCreateDraft", () => {
     resolveRepoBaseBranch.mockRejectedValue(new BaseBranchResolutionError("/tmp/repo", "origin"));
 
     await expect(
-      ghPrCreateDraft(repo, "dm/gh-pr-create-draft-v2", {
+      ghPrCreateDraft(repo, "user/gh-pr-create-draft-v2", {
         title: "Add draft PR tool",
         body: "",
       }),
@@ -121,7 +121,7 @@ describe("ghPrCreateDraft", () => {
     resolveRepoBaseBranch.mockResolvedValue("main");
 
     await expect(
-      ghPrCreateDraft(repo, "dm/gh-pr-create-draft-v2", {
+      ghPrCreateDraft(repo, "user/gh-pr-create-draft-v2", {
         title: "Add draft PR tool",
         body: "",
       }),


### PR DESCRIPTION
## Why
The tests and docs still used `dm/` as the example personal branch prefix. That no longer matches the intended generic user-facing examples, and it also makes this repo’s branch-policy examples look more personal than they need to be.

This change updates those examples to `user/` and converts the implementation doc’s `SPEC.md` reference to a relative link so the docs stay portable across local checkouts.

## Impact
Examples in the docs and test fixtures now consistently use `user/`, which makes the repository guidance less user-specific and easier to reuse.

The only behavioral impact is in test fixtures and documentation examples; no runtime code paths changed.