### PR TITLE
branch auth: reject disallowed branch names at creation time

### DIFF
--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -55,6 +55,7 @@ src/
     git.ts
     gh.ts
   tools/
+    gitRepoPolicy.ts
     gitStatus.ts
     gitAdd.ts
     gitCommit.ts
@@ -71,6 +72,7 @@ tests/
   repoAuth.test.ts
   branchAuth.test.ts
   pathValidation.test.ts
+  gitRepoPolicy.test.ts
   gitArgs.test.ts
   ghArgs.test.ts
   integration/
@@ -141,10 +143,12 @@ Each tool should follow the same top-level policy order:
 2. Resolve the requested repository path.
 3. Canonicalize the repository path and match it to a configured repository.
 4. Verify the repository looks like a Git repository.
-5. If the tool mutates content history or remote state, read the current branch and validate it against full-match branch regexes.
-6. Run tool-specific validation.
-7. Execute the fixed command or API call.
-8. Return structured output or structured failure.
+5. If the tool is read-only and policy-oriented, return the configured repository policy.
+6. If the tool mutates content history or remote state, read the current branch and validate it against full-match branch regexes when applicable.
+7. If the tool creates a new branch, validate the requested branch name against full-match branch regexes before creating it.
+8. Run tool-specific validation.
+9. Execute the fixed command or API call.
+10. Return structured output or structured failure.
 
 This shared order matters because it keeps error behavior predictable.
 
@@ -175,6 +179,8 @@ Implementation requirements:
 Implementation note:
 
 Even if regexes are already written with `^...$`, the code should still use full-match semantics rather than substring-style matching.
+
+For branch-creation tools, validate the requested new branch name against the same full-match policy before creating and switching to it. This keeps branch creation aligned with the later mutation rules instead of letting an invalid branch name survive until `git_add`, `git_commit`, or `git_push`.
 
 ## Path Validation For `git_add`
 
@@ -407,6 +413,7 @@ Validation:
 - repository must be allowlisted
 - worktree must be clean
 - `new_branch` must be non-empty after trimming
+- `new_branch` must match at least one configured allowed branch pattern
 - `new_branch` must not already exist
 - resolve the remote by preferring configured `default_remote`, then the current branch remote, then `origin`
 - if `branch` is provided, treat it as the upstream base branch name
@@ -596,6 +603,7 @@ Live GitHub integration tests can be deferred until later.
 ### Completed Core Workflow
 
 - config loading and authorization
+- `git_repo_policy`
 - `git_status`
 - `git_add`
 - `git_commit`

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ For the suggested repository workflow used in this repo (and in general), see [A
 
 Current tool surface:
 
+- `git_repo_policy`
 - `git_status`
 - `git_add`
 - `git_commit`
@@ -56,9 +57,11 @@ Notes:
 
 - `path` must be an absolute path or start with `~/`
 - branch patterns are full-match regexes against the current branch name
+- `git_repo_policy` returns the configured branch patterns and related repository defaults for an allowlisted repository
 - `git_add`, `git_commit`, `git_push`, and `gh_pr_create_draft` require the current branch to match one of the configured patterns
 - `git_fetch` only requires the repository to be allowlisted and fetches from the resolved remote
-- `git_branch_create_and_switch` and `git_branch_switch` require a clean worktree but do not require the current branch to match `allowed_branch_patterns`
+- `git_branch_create_and_switch` and `git_branch_switch` require a clean worktree
+- `git_branch_create_and_switch` also requires the requested new branch name to match `allowed_branch_patterns`
 - remote resolution prefers configured `default_remote` when present and valid, then the current branch's remote, then `origin`
 - branch creation and PR base resolution prefer the remote HEAD branch and fall back to GitHub default-branch detection when needed
 - `git_status` only requires the repository to be allowlisted
@@ -67,7 +70,7 @@ Notes:
 
 The intended happy path is:
 
-1. Call `git_status` to inspect the allowlisted repository.
+1. Call `git_repo_policy` or `git_status` to inspect the allowlisted repository.
 2. Call `git_branch_create_and_switch` to branch from an explicit or detected upstream base when you need a new local branch.
 3. Call `git_add` with explicit repository-relative paths.
 4. Call `git_commit` with a normal commit message.
@@ -137,6 +140,7 @@ The wrapper will also try `launchctl getenv SSH_AUTH_SOCK` on macOS before faili
 
 Once registered, Codex should be able to use:
 
+- `git_repo_policy` to inspect the configured branch patterns and related defaults for an allowlisted repository
 - `git_status` for an allowlisted repository
 - `git_add` for repository-relative paths inside an allowlisted repository
 - `git_commit` with a normal commit message on an allowed branch
@@ -148,9 +152,11 @@ Once registered, Codex should be able to use:
 
 Current behavior:
 
+- `git_repo_policy` returns the configured path, canonical path, allowed branch patterns, default remote, and draft-PR setting for an allowlisted repository
 - `git_add` rejects absolute paths and repository-escaping paths like `../x`
 - `git_commit` rejects empty commit messages
 - `git_commit` rejects empty commits
+- `git_branch_create_and_switch` rejects requested branch names that do not match the configured allowed branch patterns
 - `git_branch_create_and_switch` resolves the remote at runtime, uses the explicit base branch when provided or detects one otherwise, fetches that base, creates the local branch, and switches to it
 - `git_branch_switch` only switches to an explicit existing local branch and rejects dirty worktrees
 - `git_fetch` only fetches `git fetch <resolved-remote> <branch>` and defaults the branch to `main`

--- a/SPEC.md
+++ b/SPEC.md
@@ -32,6 +32,7 @@ The initial tool surface should be fixed and explicit.
 
 ### Git tools
 
+- `git_repo_policy`
 - `git_status`
 - `git_add`
 - `git_commit`
@@ -79,9 +80,10 @@ At minimum, mutating operations include:
 
 Branch-workflow exception:
 
-- `git_branch_create_and_switch` and `git_branch_switch` are mutating but may be allowed without current-branch pattern checks as long as they preserve the clean-worktree and constrained-ref safety rules
+- `git_branch_create_and_switch` and `git_branch_switch` may be allowed without current-branch pattern checks as long as they preserve the clean-worktree and constrained-ref safety rules
+- `git_branch_create_and_switch` must still validate the requested `new_branch` name against the configured allowed branch patterns before creating and switching to it
 
-Read-only operations such as `git_status` may still require repository allowlisting, but do not necessarily need branch checks unless implementation simplicity makes a uniform check preferable.
+Read-only operations such as `git_repo_policy` and `git_status` may still require repository allowlisting, but do not necessarily need branch checks unless implementation simplicity makes a uniform check preferable.
 
 ## Safety Constraints
 
@@ -130,6 +132,18 @@ Requirements:
 - repository must be allowlisted
 - no mutation
 - output should be structured where practical, or at least normalized for MCP consumption
+
+### `git_repo_policy`
+
+Purpose:
+
+- show the configured policy for an allowed repository
+
+Requirements:
+
+- repository must be allowlisted
+- no mutation
+- output should include the configured allowed branch patterns and related repository defaults in a structured shape suitable for MCP consumers
 
 ### `git_add`
 
@@ -183,6 +197,7 @@ Requirements:
 
 - repository must be allowlisted
 - the worktree must be clean
+- the requested `new_branch` name must match an allowed full-match pattern for the repository
 - the tool must infer the remote at runtime, preferring the current branch remote, then `origin`, with configuration override allowed
 - the tool may accept an explicit plain branch name as the upstream base branch
 - when no base branch is provided, the tool must infer the base branch from the remote HEAD first, with GitHub default-branch lookup as a fallback

--- a/src/auth/branchAuth.ts
+++ b/src/auth/branchAuth.ts
@@ -1,4 +1,4 @@
-import { BranchNotAllowedError, DetachedHeadError } from "../errors.js";
+import { BranchNameNotAllowedError, BranchNotAllowedError, DetachedHeadError } from "../errors.js";
 import { getCurrentBranch } from "../exec/git.js";
 import type { RepoPolicy } from "../types/config.js";
 
@@ -8,12 +8,23 @@ export async function requireAllowedBranch(repo: RepoPolicy): Promise<string> {
     throw new DetachedHeadError(repo.canonicalPath);
   }
 
-  const isAllowed = repo.allowedBranchPatterns.some((pattern) => fullMatch(pattern, branch));
-  if (!isAllowed) {
+  if (!isAllowedBranchName(repo, branch)) {
     throw new BranchNotAllowedError(branch, repo.canonicalPath);
   }
 
   return branch;
+}
+
+export function requireAllowedBranchName(repo: RepoPolicy, branch: string): string {
+  if (!isAllowedBranchName(repo, branch)) {
+    throw new BranchNameNotAllowedError(branch, repo.canonicalPath);
+  }
+
+  return branch;
+}
+
+export function isAllowedBranchName(repo: RepoPolicy, branch: string): boolean {
+  return repo.allowedBranchPatterns.some((pattern) => fullMatch(pattern, branch));
 }
 
 export function fullMatch(pattern: RegExp, value: string): boolean {

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -19,6 +19,13 @@ export class BranchNotAllowedError extends Error {
   }
 }
 
+export class BranchNameNotAllowedError extends Error {
+  constructor(branch: string, repoPath: string) {
+    super(`requested branch '${branch}' does not match allowed patterns for repository '${repoPath}'`);
+    this.name = "BranchNameNotAllowedError";
+  }
+}
+
 export class DetachedHeadError extends Error {
   constructor(repoPath: string) {
     super(`repository '${repoPath}' is in detached HEAD state`);

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -14,14 +14,18 @@ export class RepoNotAllowedError extends Error {
 
 export class BranchNotAllowedError extends Error {
   constructor(branch: string, repoPath: string) {
-    super(`branch '${branch}' does not match allowed patterns for repository '${repoPath}'`);
+    super(
+      `branch '${branch}' does not match allowed patterns for repository '${repoPath}'; call 'git_repo_policy' to inspect the allowed branch patterns for this repository`,
+    );
     this.name = "BranchNotAllowedError";
   }
 }
 
 export class BranchNameNotAllowedError extends Error {
   constructor(branch: string, repoPath: string) {
-    super(`requested branch '${branch}' does not match allowed patterns for repository '${repoPath}'`);
+    super(
+      `requested branch '${branch}' does not match allowed patterns for repository '${repoPath}'; call 'git_repo_policy' to inspect the allowed branch patterns for this repository`,
+    );
     this.name = "BranchNameNotAllowedError";
   }
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -11,6 +11,7 @@ import { ghPrCreateDraft } from "./tools/ghPrCreateDraft.js";
 import { gitCommit } from "./tools/gitCommit.js";
 import { gitFetch } from "./tools/gitFetch.js";
 import { gitPush } from "./tools/gitPush.js";
+import { getGitRepoPolicy } from "./tools/gitRepoPolicy.js";
 import { getGitStatus } from "./tools/gitStatus.js";
 
 export function createServer(config: Config): McpServer {
@@ -18,6 +19,27 @@ export function createServer(config: Config): McpServer {
     name: "codex-git-unleash-mcp",
     version: "0.1.0",
   });
+
+  server.tool(
+    "git_repo_policy",
+    "Return the configured policy for an allowlisted repository. This tool is read-only and exposes the branch patterns and related repository defaults that other tools enforce.",
+    {
+      repo_path: z.string().min(1),
+    },
+    async ({ repo_path }) => {
+      const repo = await resolveAllowedRepo(config, repo_path);
+      const result = getGitRepoPolicy(repo);
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(result, null, 2),
+          },
+        ],
+      };
+    },
+  );
 
   server.tool(
     "git_status",

--- a/src/tools/gitBranchCreateAndSwitch.ts
+++ b/src/tools/gitBranchCreateAndSwitch.ts
@@ -1,3 +1,4 @@
+import { requireAllowedBranchName } from "../auth/branchAuth.js";
 import { BranchAlreadyExistsError, DirtyWorktreeError, EmptyBranchNameError } from "../errors.js";
 import { branchExists, createBranch, fetchBranch, switchBranch } from "../exec/git.js";
 import type { RepoPolicy } from "../types/config.js";
@@ -18,6 +19,7 @@ export async function gitBranchCreateAndSwitch(
   if (!normalizedBranch) {
     throw new EmptyBranchNameError();
   }
+  requireAllowedBranchName(repo, normalizedBranch);
 
   const status = await getGitStatus(repo);
   if (!status.isClean) {

--- a/src/tools/gitRepoPolicy.ts
+++ b/src/tools/gitRepoPolicy.ts
@@ -1,0 +1,19 @@
+import type { RepoPolicy } from "../types/config.js";
+
+export type GitRepoPolicyResult = {
+  path: string;
+  canonicalPath: string;
+  allowedBranchPatterns: string[];
+  defaultRemote?: string;
+  allowDraftPrs: boolean;
+};
+
+export function getGitRepoPolicy(repo: RepoPolicy): GitRepoPolicyResult {
+  return {
+    path: repo.path,
+    canonicalPath: repo.canonicalPath,
+    allowedBranchPatterns: repo.allowedBranchPatterns.map((pattern) => pattern.source),
+    defaultRemote: repo.defaultRemote,
+    allowDraftPrs: repo.allowDraftPrs,
+  };
+}

--- a/tests/gitBranchCreateAndSwitch.test.ts
+++ b/tests/gitBranchCreateAndSwitch.test.ts
@@ -3,7 +3,12 @@ import path from "node:path";
 
 import { afterEach, describe, expect, it } from "vitest";
 
-import { BranchAlreadyExistsError, DirtyWorktreeError, EmptyBranchNameError } from "../src/errors.js";
+import {
+  BranchAlreadyExistsError,
+  BranchNameNotAllowedError,
+  DirtyWorktreeError,
+  EmptyBranchNameError,
+} from "../src/errors.js";
 import {
   getCurrentBranch,
   gitCreateBranchArgs,
@@ -109,6 +114,21 @@ describe("gitBranchCreateAndSwitch", () => {
     await expect(gitBranchCreateAndSwitch(repo, { newBranch: "   " })).rejects.toBeInstanceOf(
       EmptyBranchNameError,
     );
+  });
+
+  it("rejects branch names that do not match allowed patterns", async () => {
+    const { repoDir, repo } = await createTempGitRepo();
+    tempPaths.push(repoDir);
+
+    await expect(
+      gitBranchCreateAndSwitch(
+        {
+          ...repo,
+          allowedBranchPatterns: [/^feature\/.+$/],
+        },
+        { newBranch: "codex/disallowed" },
+      ),
+    ).rejects.toBeInstanceOf(BranchNameNotAllowedError);
   });
 
   it("uses an explicit upstream branch when provided", async () => {

--- a/tests/gitRepoPolicy.test.ts
+++ b/tests/gitRepoPolicy.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+
+import { getGitRepoPolicy } from "../src/tools/gitRepoPolicy.js";
+import type { RepoPolicy } from "../src/types/config.js";
+
+describe("getGitRepoPolicy", () => {
+  it("returns the configured repository policy in a serializable shape", () => {
+    const repo: RepoPolicy = {
+      path: "/tmp/repo",
+      canonicalPath: "/private/tmp/repo",
+      allowedBranchPatterns: [/^dm\/.*$/, /^feature\/[a-z0-9._-]+$/],
+      defaultRemote: "origin",
+      allowDraftPrs: true,
+    };
+
+    expect(getGitRepoPolicy(repo)).toEqual({
+      path: "/tmp/repo",
+      canonicalPath: "/private/tmp/repo",
+      allowedBranchPatterns: ["^dm\\/.*$", "^feature\\/[a-z0-9._-]+$"],
+      defaultRemote: "origin",
+      allowDraftPrs: true,
+    });
+  });
+});


### PR DESCRIPTION
## Why
`git_branch_create_and_switch` allowed any non-empty branch name, even when that name did not match the repository's `allowed_branch_patterns`. That meant a caller could successfully create and switch to a branch that would only be rejected later by add or commit operations.

This change moves that policy check to branch creation time so the failure happens at the point where the invalid branch name is requested.

## Impact
Branch creation now fails fast for disallowed branch names, which keeps the workflow aligned with repository branch policy and avoids later-stage surprises.

The behavioral change is intentional and covered by a regression test for rejected branch names, alongside the existing successful branch-creation coverage.