### PR TITLE
docs: require branch names to follow git_unleash policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 
 For this repository, the following end-to-end workflow is required for repository changes:
 
-1. create and switch to a new branch from the detected upstream base
+1. inspect the repository policy and create and switch to a new branch from the detected upstream base
 2. do planning and coding work
 3. commit changes (prefer smaller, targeted commits)
 4. push the current branch
@@ -12,5 +12,7 @@ For this repository, the following end-to-end workflow is required for repositor
 6. address PR review comments and iterate as needed, preferably one comment at a time or grouped by theme
 
 Do not begin planning edits or making repository changes on the current branch before step 1 is complete.
+
+Before creating a development branch, call `git_unleash.git_repo_policy` and choose a branch name that matches the configured `allowed_branch_patterns`. Do not assume a default prefix or reuse a prefix from another repository.
 
 The Git and GitHub operations for the steps above must be performed using the `git_unleash` MCP.

--- a/README.md
+++ b/README.md
@@ -71,11 +71,12 @@ Notes:
 The intended happy path is:
 
 1. Call `git_repo_policy` or `git_status` to inspect the allowlisted repository.
-2. Call `git_branch_create_and_switch` to branch from an explicit or detected upstream base when you need a new local branch.
-3. Call `git_add` with explicit repository-relative paths.
-4. Call `git_commit` with a normal commit message.
-5. Call `git_push` to push the current branch to the resolved remote.
-6. Call `gh_pr_create_draft` to open a draft PR against an explicit base or the detected default base branch.
+2. Before creating a branch, use `git_repo_policy` to confirm the configured `allowed_branch_patterns`, then choose a new branch name that matches that policy.
+3. Call `git_branch_create_and_switch` to branch from an explicit or detected upstream base when you need a new local branch.
+4. Call `git_add` with explicit repository-relative paths.
+5. Call `git_commit` with a normal commit message.
+6. Call `git_push` to push the current branch to the resolved remote.
+7. Call `gh_pr_create_draft` to open a draft PR against an explicit base or the detected default base branch.
 
 Each step stays inside a fixed policy boundary. There is no arbitrary checkout, no arbitrary push refspec, no amend flow, and no non-draft PR creation.
 


### PR DESCRIPTION
## Why
Agents using this repository's workflow were told to create a new branch and use `git_unleash`, but the instructions did not explicitly tell them to inspect repository policy and choose a branch name that matches the configured `allowed_branch_patterns`.

That gap makes the branch naming constraint easy to miss until `git_unleash` rejects a branch creation or mutation.

## What changed
- updated `AGENTS.md` to require calling `git_unleash.git_repo_policy` before creating a development branch
- clarified that agents must choose a branch name that matches `allowed_branch_patterns`
- updated the README workflow summary to include the same step without naming any repo-specific prefix

## Impact
This makes the branch naming requirement explicit while keeping the instruction generic and repository-agnostic.

Potential downside: agents now have one extra lookup step before branch creation, but that is the correct source of truth and avoids hardcoded prefixes leaking across repositories.