### PR TITLE
Support linked git worktree paths in MCP repository resolution

### DIFF
--- a/src/auth/branchAuth.ts
+++ b/src/auth/branchAuth.ts
@@ -3,13 +3,13 @@ import { getCurrentBranch } from "../exec/git.js";
 import type { RepoPolicy } from "../types/config.js";
 
 export async function requireAllowedBranch(repo: RepoPolicy): Promise<string> {
-  const branch = await getCurrentBranch(repo.canonicalPath);
+  const branch = await getCurrentBranch(repo.worktreePath);
   if (!branch) {
-    throw new DetachedHeadError(repo.canonicalPath);
+    throw new DetachedHeadError(repo.worktreePath);
   }
 
   if (!isAllowedBranchName(repo, branch)) {
-    throw new BranchNotAllowedError(branch, repo.canonicalPath);
+    throw new BranchNotAllowedError(branch, repo.worktreePath);
   }
 
   return branch;
@@ -17,7 +17,7 @@ export async function requireAllowedBranch(repo: RepoPolicy): Promise<string> {
 
 export function requireAllowedBranchName(repo: RepoPolicy, branch: string): string {
   if (!isAllowedBranchName(repo, branch)) {
-    throw new BranchNameNotAllowedError(branch, repo.canonicalPath);
+    throw new BranchNameNotAllowedError(branch, repo.worktreePath);
   }
 
   return branch;

--- a/src/auth/repoAuth.ts
+++ b/src/auth/repoAuth.ts
@@ -2,22 +2,47 @@ import fs from "node:fs/promises";
 import path from "node:path";
 
 import { RepoNotAllowedError } from "../errors.js";
-import { getGitTopLevel } from "../exec/git.js";
+import { getGitCommonDir, getGitTopLevel } from "../exec/git.js";
 import type { Config, RepoPolicy } from "../types/config.js";
 
 export async function resolveAllowedRepo(config: Config, repoPath: string): Promise<RepoPolicy> {
   const absolutePath = path.resolve(repoPath);
-  const canonicalPath = await fs.realpath(absolutePath);
+  const resolvedRepo = await resolveRequestedRepo(absolutePath);
+  if (!resolvedRepo) {
+    throw new RepoNotAllowedError(absolutePath);
+  }
 
-  const repo = config.repositories.find((candidate) => candidate.canonicalPath === canonicalPath);
+  const repo = await findMatchingRepo(config, resolvedRepo.commonDir);
   if (!repo) {
     throw new RepoNotAllowedError(absolutePath);
   }
 
-  const topLevel = await fs.realpath(await getGitTopLevel(repo.canonicalPath));
-  if (topLevel !== repo.canonicalPath) {
-    throw new RepoNotAllowedError(absolutePath);
+  return {
+    ...repo,
+    worktreePath: resolvedRepo.topLevel,
+  };
+}
+
+async function findMatchingRepo(config: Config, commonDir: string): Promise<RepoPolicy | undefined> {
+  for (const candidate of config.repositories) {
+    if ((await getGitCommonDir(candidate.canonicalPath)) === commonDir) {
+      return candidate;
+    }
   }
 
-  return repo;
+  return undefined;
+}
+
+async function resolveRequestedRepo(
+  absolutePath: string,
+): Promise<{ topLevel: string; commonDir: string } | null> {
+  try {
+    const canonicalPath = await fs.realpath(absolutePath);
+    return {
+      topLevel: await fs.realpath(await getGitTopLevel(canonicalPath)),
+      commonDir: await getGitCommonDir(canonicalPath),
+    };
+  } catch {
+    return null;
+  }
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -54,6 +54,7 @@ export async function loadConfig(configPath: string): Promise<Config> {
     repositories.push({
       path: expandedPath,
       canonicalPath,
+      worktreePath: canonicalPath,
       allowedBranchPatterns,
       defaultRemote: repo.default_remote,
       allowDraftPrs: repo.allow_draft_prs ?? true,

--- a/src/exec/git.ts
+++ b/src/exec/git.ts
@@ -1,4 +1,6 @@
+import fs from "node:fs/promises";
 import { runCommand } from "./run.js";
+import path from "node:path";
 
 export function gitStatusArgs(): string[] {
   return ["status", "--short", "--branch"];
@@ -48,6 +50,16 @@ export async function getGitTopLevel(cwd: string): Promise<string> {
   });
 
   return result.stdout.trim();
+}
+
+export async function getGitCommonDir(cwd: string): Promise<string> {
+  const result = await runCommand({
+    cwd,
+    command: "git",
+    argv: ["rev-parse", "--git-common-dir"],
+  });
+
+  return await resolveGitPath(cwd, result.stdout.trim());
 }
 
 export async function getCurrentBranch(cwd: string): Promise<string> {
@@ -199,4 +211,8 @@ export async function getHeadCommit(cwd: string): Promise<{ oid: string; summary
 
   const [oid = "", summary = ""] = result.stdout.trimEnd().split("\n");
   return { oid, summary };
+}
+
+async function resolveGitPath(cwd: string, gitPath: string): Promise<string> {
+  return await fs.realpath(path.resolve(cwd, gitPath));
 }

--- a/src/tools/ghPrCreateDraft.ts
+++ b/src/tools/ghPrCreateDraft.ts
@@ -25,7 +25,7 @@ export async function ghPrCreateDraft(
 
   const requestedBase = input.base?.trim();
   const base = requestedBase || (await resolveRepoBaseBranch(repo, await resolveRepoRemote(repo)));
-  const url = await createDraftPullRequest(repo.canonicalPath, {
+  const url = await createDraftPullRequest(repo.worktreePath, {
     base,
     title,
     body: input.body,

--- a/src/tools/gitAdd.ts
+++ b/src/tools/gitAdd.ts
@@ -7,8 +7,8 @@ export type GitAddResult = {
 };
 
 export async function gitAdd(repo: RepoPolicy, inputPaths: string[]): Promise<GitAddResult> {
-  const validatedPaths = validateRepoRelativePaths(repo.canonicalPath, inputPaths);
-  await addPaths(repo.canonicalPath, validatedPaths);
+  const validatedPaths = validateRepoRelativePaths(repo.worktreePath, inputPaths);
+  await addPaths(repo.worktreePath, validatedPaths);
 
   return { addedPaths: validatedPaths };
 }

--- a/src/tools/gitBranchCreateAndSwitch.ts
+++ b/src/tools/gitBranchCreateAndSwitch.ts
@@ -23,19 +23,19 @@ export async function gitBranchCreateAndSwitch(
 
   const status = await getGitStatus(repo);
   if (!status.isClean) {
-    throw new DirtyWorktreeError(repo.canonicalPath);
+    throw new DirtyWorktreeError(repo.worktreePath);
   }
 
-  if (await branchExists(repo.canonicalPath, normalizedBranch)) {
-    throw new BranchAlreadyExistsError(normalizedBranch, repo.canonicalPath);
+  if (await branchExists(repo.worktreePath, normalizedBranch)) {
+    throw new BranchAlreadyExistsError(normalizedBranch, repo.worktreePath);
   }
 
   const remote = await resolveRepoRemote(repo);
   const base = input.branch?.trim() || (await resolveRepoBaseBranch(repo, remote));
 
-  await fetchBranch(repo.canonicalPath, remote, base);
-  await createBranch(repo.canonicalPath, normalizedBranch, `refs/remotes/${remote}/${base}`);
-  await switchBranch(repo.canonicalPath, normalizedBranch);
+  await fetchBranch(repo.worktreePath, remote, base);
+  await createBranch(repo.worktreePath, normalizedBranch, `refs/remotes/${remote}/${base}`);
+  await switchBranch(repo.worktreePath, normalizedBranch);
 
   return {
     branch: normalizedBranch,

--- a/src/tools/gitBranchSwitch.ts
+++ b/src/tools/gitBranchSwitch.ts
@@ -15,14 +15,14 @@ export async function gitBranchSwitch(repo: RepoPolicy, branch: string): Promise
 
   const status = await getGitStatus(repo);
   if (!status.isClean) {
-    throw new DirtyWorktreeError(repo.canonicalPath);
+    throw new DirtyWorktreeError(repo.worktreePath);
   }
 
-  if (!(await branchExists(repo.canonicalPath, normalizedBranch))) {
-    throw new BranchNotFoundError(normalizedBranch, repo.canonicalPath);
+  if (!(await branchExists(repo.worktreePath, normalizedBranch))) {
+    throw new BranchNotFoundError(normalizedBranch, repo.worktreePath);
   }
 
-  await switchBranch(repo.canonicalPath, normalizedBranch);
+  await switchBranch(repo.worktreePath, normalizedBranch);
 
   return { branch: normalizedBranch };
 }

--- a/src/tools/gitCommit.ts
+++ b/src/tools/gitCommit.ts
@@ -13,13 +13,13 @@ export async function gitCommit(repo: RepoPolicy, message: string): Promise<GitC
     throw new EmptyCommitMessageError();
   }
 
-  const stagedChanges = await hasStagedChanges(repo.canonicalPath);
+  const stagedChanges = await hasStagedChanges(repo.worktreePath);
   if (!stagedChanges) {
-    throw new EmptyCommitError(repo.canonicalPath);
+    throw new EmptyCommitError(repo.worktreePath);
   }
 
-  await createCommit(repo.canonicalPath, normalizedMessage);
-  const headCommit = await getHeadCommit(repo.canonicalPath);
+  await createCommit(repo.worktreePath, normalizedMessage);
+  const headCommit = await getHeadCommit(repo.worktreePath);
 
   return {
     commitOid: headCommit.oid,

--- a/src/tools/gitFetch.ts
+++ b/src/tools/gitFetch.ts
@@ -16,7 +16,7 @@ export async function gitFetch(repo: RepoPolicy, input: { branch?: string }): Pr
     throw new PathValidationError(`branch '${branch}' must be a plain branch name`);
   }
 
-  await fetchBranch(repo.canonicalPath, remote, branch);
+  await fetchBranch(repo.worktreePath, remote, branch);
 
   return {
     remote,

--- a/src/tools/gitPush.ts
+++ b/src/tools/gitPush.ts
@@ -9,7 +9,7 @@ export type GitPushResult = {
 
 export async function gitPush(repo: RepoPolicy, branch: string): Promise<GitPushResult> {
   const remote = await resolveRepoRemote(repo);
-  await pushBranch(repo.canonicalPath, remote, branch);
+  await pushBranch(repo.worktreePath, remote, branch);
 
   return {
     remote,

--- a/src/tools/gitStatus.ts
+++ b/src/tools/gitStatus.ts
@@ -8,8 +8,8 @@ type GitStatusResult = {
 };
 
 export async function getGitStatus(repo: RepoPolicy): Promise<GitStatusResult> {
-  const stdout = await getStatus(repo.canonicalPath);
-  const branch = parseBranch(stdout) ?? (await safeCurrentBranch(repo.canonicalPath));
+  const stdout = await getStatus(repo.worktreePath);
+  const branch = parseBranch(stdout) ?? (await safeCurrentBranch(repo.worktreePath));
 
   return {
     branch,

--- a/src/tools/runtimeDefaults.ts
+++ b/src/tools/runtimeDefaults.ts
@@ -10,36 +10,36 @@ import type { RepoPolicy } from "../types/config.js";
 
 export async function resolveRepoRemote(repo: RepoPolicy): Promise<string> {
   if (repo.defaultRemote) {
-    if (await remoteExists(repo.canonicalPath, repo.defaultRemote)) {
+    if (await remoteExists(repo.worktreePath, repo.defaultRemote)) {
       return repo.defaultRemote;
     }
   }
 
-  const currentBranch = await getCurrentBranch(repo.canonicalPath);
+  const currentBranch = await getCurrentBranch(repo.worktreePath);
   if (currentBranch) {
-    const branchRemote = await getBranchRemote(repo.canonicalPath, currentBranch);
-    if (branchRemote && (await remoteExists(repo.canonicalPath, branchRemote))) {
+    const branchRemote = await getBranchRemote(repo.worktreePath, currentBranch);
+    if (branchRemote && (await remoteExists(repo.worktreePath, branchRemote))) {
       return branchRemote;
     }
   }
 
-  if (await remoteExists(repo.canonicalPath, "origin")) {
+  if (await remoteExists(repo.worktreePath, "origin")) {
     return "origin";
   }
 
-  throw new RemoteResolutionError(repo.canonicalPath);
+  throw new RemoteResolutionError(repo.worktreePath);
 }
 
 export async function resolveRepoBaseBranch(repo: RepoPolicy, remote: string): Promise<string> {
-  const remoteHeadBranch = await getRemoteHeadBranch(repo.canonicalPath, remote);
+  const remoteHeadBranch = await getRemoteHeadBranch(repo.worktreePath, remote);
   if (remoteHeadBranch) {
     return remoteHeadBranch;
   }
 
-  const ghDefaultBranch = await getRepoDefaultBranch(repo.canonicalPath);
+  const ghDefaultBranch = await getRepoDefaultBranch(repo.worktreePath);
   if (ghDefaultBranch) {
     return ghDefaultBranch;
   }
 
-  throw new BaseBranchResolutionError(repo.canonicalPath, remote);
+  throw new BaseBranchResolutionError(repo.worktreePath, remote);
 }

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -1,6 +1,7 @@
 export type RepoPolicy = {
   path: string;
   canonicalPath: string;
+  worktreePath: string;
   allowedBranchPatterns: RegExp[];
   defaultRemote?: string;
   allowDraftPrs: boolean;

--- a/tests/ghPrCreateDraft.test.ts
+++ b/tests/ghPrCreateDraft.test.ts
@@ -29,6 +29,7 @@ vi.mock("../src/tools/runtimeDefaults.js", () => ({
 const repo: RepoPolicy = {
   path: "/tmp/repo",
   canonicalPath: "/tmp/repo",
+  worktreePath: "/tmp/repo",
   allowedBranchPatterns: [/^user\/.*$/],
   allowDraftPrs: true,
 };

--- a/tests/gitBranchCreateAndSwitch.test.ts
+++ b/tests/gitBranchCreateAndSwitch.test.ts
@@ -20,7 +20,7 @@ import { gitAdd } from "../src/tools/gitAdd.js";
 import { gitBranchCreateAndSwitch } from "../src/tools/gitBranchCreateAndSwitch.js";
 import { gitCommit } from "../src/tools/gitCommit.js";
 import { gitPush } from "../src/tools/gitPush.js";
-import { createTempBareGitRepo, createTempGitRepo } from "./helpers.js";
+import { createLinkedWorktree, createTempBareGitRepo, createTempGitRepo } from "./helpers.js";
 
 const tempPaths: string[] = [];
 
@@ -182,6 +182,42 @@ describe("gitBranchCreateAndSwitch", () => {
     });
     expect(headAfter).toBe("feature/from-release");
     expect(newBranchOid.stdout.trim()).toBe(remoteReleaseOid.stdout.trim());
+  });
+
+  it("creates and switches the branch in a linked worktree", async () => {
+    const { repoDir, repo } = await createTempGitRepo();
+    const remoteDir = await createTempBareGitRepo();
+    const worktreeDir = path.join(path.dirname(repoDir), "git-mcp-worktree-linked");
+    tempPaths.push(repoDir, remoteDir, worktreeDir);
+
+    await runCommand({ cwd: repoDir, command: "git", argv: ["remote", "add", "origin", remoteDir] });
+    await fs.writeFile(path.join(repoDir, "README.md"), "hello\n", "utf8");
+    await gitAdd(repo, ["README.md"]);
+    await gitCommit(repo, "add readme");
+    await gitPush(repo, "main");
+    await runCommand({
+      cwd: remoteDir,
+      command: "git",
+      argv: ["symbolic-ref", "HEAD", "refs/heads/main"],
+    });
+
+    const linkedWorktree = await createLinkedWorktree(repoDir, worktreeDir);
+    const result = await gitBranchCreateAndSwitch(
+      {
+        ...repo,
+        worktreePath: linkedWorktree,
+        allowedBranchPatterns: [/^feature\/.+$/],
+      },
+      { newBranch: "feature/from-worktree" },
+    );
+
+    await expect(getCurrentBranch(linkedWorktree)).resolves.toBe("feature/from-worktree");
+    await expect(getCurrentBranch(repoDir)).resolves.toBe("main");
+    expect(result).toEqual({
+      branch: "feature/from-worktree",
+      remote: "origin",
+      base: "main",
+    });
   });
 
   it("uses fixed git fetch, branch creation, and remote-head argument shapes", () => {

--- a/tests/gitRepoPolicy.test.ts
+++ b/tests/gitRepoPolicy.test.ts
@@ -8,6 +8,7 @@ describe("getGitRepoPolicy", () => {
     const repo: RepoPolicy = {
       path: "/tmp/repo",
       canonicalPath: "/private/tmp/repo",
+      worktreePath: "/private/tmp/repo",
       allowedBranchPatterns: [/^dm\/.*$/, /^feature\/[a-z0-9._-]+$/],
       defaultRemote: "origin",
       allowDraftPrs: true,

--- a/tests/gitStatus.test.ts
+++ b/tests/gitStatus.test.ts
@@ -5,7 +5,8 @@ import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { getGitStatus } from "../src/tools/gitStatus.js";
-import { createTempGitRepo } from "./helpers.js";
+import { runCommand } from "../src/exec/run.js";
+import { createLinkedWorktree, createTempGitRepo } from "./helpers.js";
 
 const tempPaths: string[] = [];
 
@@ -24,5 +25,27 @@ describe("getGitStatus", () => {
     expect(status.branch).toBeTruthy();
     expect(status.isClean).toBe(false);
     expect(status.stdout).toContain("README.md");
+  });
+
+  it("reads status from a linked worktree instead of the configured main checkout", async () => {
+    const { repoDir, repo } = await createTempGitRepo();
+    const worktreeDir = path.join(os.tmpdir(), `git-mcp-worktree-${Math.random().toString(16).slice(2)}`);
+    tempPaths.push(repoDir, worktreeDir);
+
+    await fs.writeFile(path.join(repoDir, "README.md"), "hello\n", "utf8");
+    await runCommand({ cwd: repoDir, command: "git", argv: ["add", "README.md"] });
+    await runCommand({ cwd: repoDir, command: "git", argv: ["commit", "-m", "init"] });
+
+    const linkedWorktree = await createLinkedWorktree(repoDir, worktreeDir);
+    await fs.writeFile(path.join(linkedWorktree, "WORKTREE.md"), "only here\n", "utf8");
+
+    const status = await getGitStatus({
+      ...repo,
+      worktreePath: linkedWorktree,
+    });
+
+    expect(status.isClean).toBe(false);
+    expect(status.stdout).toContain("WORKTREE.md");
+    expect(status.stdout).not.toContain("README.md");
   });
 });

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -17,6 +17,7 @@ export async function createTempGitRepo(): Promise<{ repoDir: string; repo: Repo
     repo: {
       path: repoDir,
       canonicalPath: await fs.realpath(repoDir),
+      worktreePath: await fs.realpath(repoDir),
       allowedBranchPatterns: [/^.*$/],
       allowDraftPrs: true,
     },
@@ -27,4 +28,14 @@ export async function createTempBareGitRepo(): Promise<string> {
   const repoDir = await fs.mkdtemp(path.join(os.tmpdir(), "git-mcp-remote-"));
   await runCommand({ cwd: repoDir, command: "git", argv: ["init", "--bare"] });
   return repoDir;
+}
+
+export async function createLinkedWorktree(repoDir: string, worktreeDir: string): Promise<string> {
+  await runCommand({
+    cwd: repoDir,
+    command: "git",
+    argv: ["worktree", "add", "--detach", worktreeDir, "HEAD"],
+  });
+
+  return await fs.realpath(worktreeDir);
 }

--- a/tests/repoAuth.test.ts
+++ b/tests/repoAuth.test.ts
@@ -6,7 +6,9 @@ import { afterEach, describe, expect, it } from "vitest";
 
 import { resolveAllowedRepo } from "../src/auth/repoAuth.js";
 import { RepoNotAllowedError } from "../src/errors.js";
+import { runCommand } from "../src/exec/run.js";
 import type { Config } from "../src/types/config.js";
+import { createLinkedWorktree, createTempGitRepo } from "./helpers.js";
 
 const tempPaths: string[] = [];
 
@@ -24,6 +26,7 @@ describe("resolveAllowedRepo", () => {
         {
           path: "/tmp/other",
           canonicalPath: "/tmp/other",
+          worktreePath: "/tmp/other",
           allowedBranchPatterns: [/^feature\/.+$/],
           allowDraftPrs: true,
         },
@@ -31,5 +34,26 @@ describe("resolveAllowedRepo", () => {
     };
 
     await expect(resolveAllowedRepo(config, repoDir)).rejects.toBeInstanceOf(RepoNotAllowedError);
+  });
+
+  it("accepts a linked worktree for an allowlisted repository", async () => {
+    const { repoDir, repo } = await createTempGitRepo();
+    const worktreeDir = path.join(os.tmpdir(), `git-mcp-worktree-${Math.random().toString(16).slice(2)}`);
+    tempPaths.push(repoDir, worktreeDir);
+
+    await fs.writeFile(path.join(repoDir, "README.md"), "hello\n", "utf8");
+    await runCommand({ cwd: repoDir, command: "git", argv: ["add", "README.md"] });
+    await runCommand({ cwd: repoDir, command: "git", argv: ["commit", "-m", "init"] });
+
+    const linkedWorktree = await createLinkedWorktree(repoDir, worktreeDir);
+    const resolvedRepo = await resolveAllowedRepo(
+      {
+        repositories: [repo],
+      },
+      linkedWorktree,
+    );
+
+    expect(resolvedRepo.canonicalPath).toBe(repo.canonicalPath);
+    expect(resolvedRepo.worktreePath).toBe(linkedWorktree);
   });
 });


### PR DESCRIPTION
Why

Fixes #17.

The server previously treated the configured repository checkout as the only valid execution path. That meant linked Git worktrees were rejected during repository resolution or, in some code paths, operations still ran against the configured main checkout instead of the active worktree.

This change resolves allowlisted repositories by Git common dir, so linked worktrees inherit the base repository policy without requiring separate config entries. It also carries the active worktree path through the runtime repo object so branch checks, status, add/commit/push, fetch, branch creation/switching, remote/base resolution, and draft PR creation all execute in the requested worktree.

Impact

Codex can now use the constrained MCP workflow from linked worktrees while preserving the existing policy checks around allowlisted repositories, branch patterns, clean-worktree requirements, path validation, and draft-only PR creation.

The main thing to watch is path-sensitive behavior: policy identity still comes from the configured repository, but command execution now follows the resolved worktree path. Unit tests cover repository resolution plus real worktree-oriented status and branch creation behavior, and I also manually verified add/commit behavior against an actual linked worktree.