### PR TITLE
Add top-level config defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,18 +46,27 @@ Use a config file at `~/.config/codex-git-unleash-mcp.yaml`.
 Example:
 
 ```yaml
+defaults:
+  allowed_branch_patterns:
+    - "^user/.*$"
+  allow_draft_prs: true
+
 repositories:
   - path: ~/projects/codex-git-unleash-mcp
+    default_remote: origin
+  - path: ~/projects/another-repo
     allowed_branch_patterns:
-      - "^user/.*$"
       - "^feature/[a-z0-9._-]+$"
-    allow_draft_prs: true
+    allow_draft_prs: false
 ```
 
 Notes:
 
 - `path` must be an absolute path or start with `~/`
+- top-level `defaults` are optional and may define `allowed_branch_patterns`, `default_remote`, and `allow_draft_prs`
+- repository values override top-level defaults field-by-field
 - branch patterns are full-match regexes against the current branch name
+- each repository must end up with at least one effective allowed branch pattern, either from the repo entry or inherited from `defaults`
 - `git_repo_policy` returns the configured branch patterns and related repository defaults for an allowlisted repository
 - `git_add`, `git_commit`, `git_push`, and `gh_pr_create_draft` require the current branch to match one of the configured patterns
 - `git_fetch` only requires the repository to be allowlisted, fetches from the resolved remote, and uses an explicit branch when provided or the detected base branch otherwise
@@ -178,9 +187,13 @@ This keeps the tools constrained while still working across repositories that us
 If you want to branch from `main` but only allow mutations on personal feature branches:
 
 ```yaml
+defaults:
+  allowed_branch_patterns:
+    - "^user/.*$"
+
 repositories:
   - path: ~/projects/codex-git-unleash-mcp
+  - path: ~/projects/codex-git-unleash-mcp-enterprise
     allowed_branch_patterns:
-      - "^user/.*$"
       - "^feature/[a-z0-9._-]+$"
 ```

--- a/src/config.ts
+++ b/src/config.ts
@@ -8,14 +8,18 @@ import { z } from "zod";
 import { ConfigError } from "./errors.js";
 import type { Config, RepoPolicy } from "./types/config.js";
 
-const repoPolicySchema = z.object({
-  path: z.string().min(1),
-  allowed_branch_patterns: z.array(z.string().min(1)),
+const policyDefaultsSchema = z.object({
+  allowed_branch_patterns: z.array(z.string().min(1)).nonempty().optional(),
   default_remote: z.string().min(1).optional(),
   allow_draft_prs: z.boolean().optional(),
 });
 
+const repoPolicySchema = policyDefaultsSchema.extend({
+  path: z.string().min(1),
+});
+
 const configSchema = z.object({
+  defaults: policyDefaultsSchema.optional(),
   repositories: z.array(repoPolicySchema),
 });
 
@@ -39,25 +43,22 @@ export async function loadConfig(configPath: string): Promise<Config> {
       throw new ConfigError(`duplicate configured repository path '${canonicalPath}'`);
     }
 
-    const allowedBranchPatterns = repo.allowed_branch_patterns.map((pattern) => {
-      try {
-        return new RegExp(pattern);
-      } catch (error) {
-        throw new ConfigError(
-          `invalid branch regex '${pattern}' for repository '${repo.path}': ${
-            error instanceof Error ? error.message : String(error)
-          }`,
-        );
-      }
-    });
+    const patternSources = repo.allowed_branch_patterns ?? config.defaults?.allowed_branch_patterns;
+    if (!patternSources || patternSources.length === 0) {
+      throw new ConfigError(
+        `repository '${repo.path}' must define allowed_branch_patterns directly or inherit them from top-level defaults`,
+      );
+    }
+
+    const allowedBranchPatterns = compileBranchPatterns(patternSources, repo.path);
 
     repositories.push({
       path: expandedPath,
       canonicalPath,
       worktreePath: canonicalPath,
       allowedBranchPatterns,
-      defaultRemote: repo.default_remote,
-      allowDraftPrs: repo.allow_draft_prs ?? true,
+      defaultRemote: repo.default_remote ?? config.defaults?.default_remote,
+      allowDraftPrs: repo.allow_draft_prs ?? config.defaults?.allow_draft_prs ?? true,
     });
 
     seenPaths.add(canonicalPath);
@@ -80,4 +81,18 @@ function expandHomeDir(inputPath: string): string {
   }
 
   return inputPath;
+}
+
+function compileBranchPatterns(patterns: string[], repoPath: string): RegExp[] {
+  return patterns.map((pattern) => {
+    try {
+      return new RegExp(pattern);
+    } catch (error) {
+      throw new ConfigError(
+        `invalid branch regex '${pattern}' for repository '${repoPath}': ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    }
+  });
 }

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -31,6 +31,75 @@ describe("loadConfig", () => {
     expect(config.repositories[0]?.canonicalPath).toBe(canonicalRepoDir);
     expect(config.repositories[0]?.defaultRemote).toBeUndefined();
     expect(config.repositories[0]?.allowDraftPrs).toBe(true);
+    expect(config.repositories[0]?.allowedBranchPatterns.map((pattern) => pattern.source)).toEqual(["^feature\\/.+$"]);
+  });
+
+  it("inherits top-level defaults", async () => {
+    const repoDir = await fs.mkdtemp(path.join(os.tmpdir(), "git-mcp-defaults-repo-"));
+    const configPath = path.join(os.tmpdir(), `git-mcp-config-${Date.now()}-defaults.yaml`);
+    tempPaths.push(repoDir, configPath);
+
+    await fs.writeFile(
+      configPath,
+      [
+        "defaults:",
+        "  allowed_branch_patterns:",
+        '    - "^dm/.+$"',
+        "  default_remote: upstream",
+        "  allow_draft_prs: false",
+        "repositories:",
+        `  - path: ${repoDir}`,
+      ].join("\n"),
+      "utf8",
+    );
+
+    const config = await loadConfig(configPath);
+
+    expect(config.repositories[0]?.allowedBranchPatterns.map((pattern) => pattern.source)).toEqual(["^dm\\/.+$"]);
+    expect(config.repositories[0]?.defaultRemote).toBe("upstream");
+    expect(config.repositories[0]?.allowDraftPrs).toBe(false);
+  });
+
+  it("lets repositories override top-level defaults", async () => {
+    const repoDir = await fs.mkdtemp(path.join(os.tmpdir(), "git-mcp-override-repo-"));
+    const configPath = path.join(os.tmpdir(), `git-mcp-config-${Date.now()}-override.yaml`);
+    tempPaths.push(repoDir, configPath);
+
+    await fs.writeFile(
+      configPath,
+      [
+        "defaults:",
+        "  allowed_branch_patterns:",
+        '    - "^dm/.+$"',
+        "  default_remote: upstream",
+        "  allow_draft_prs: false",
+        "repositories:",
+        `  - path: ${repoDir}`,
+        "    allowed_branch_patterns:",
+        '      - "^feature/.+$"',
+        "    default_remote: origin",
+        "    allow_draft_prs: true",
+      ].join("\n"),
+      "utf8",
+    );
+
+    const config = await loadConfig(configPath);
+
+    expect(config.repositories[0]?.allowedBranchPatterns.map((pattern) => pattern.source)).toEqual(["^feature\\/.+$"]);
+    expect(config.repositories[0]?.defaultRemote).toBe("origin");
+    expect(config.repositories[0]?.allowDraftPrs).toBe(true);
+  });
+
+  it("rejects repositories without effective branch patterns", async () => {
+    const repoDir = await fs.mkdtemp(path.join(os.tmpdir(), "git-mcp-no-patterns-repo-"));
+    const configPath = path.join(os.tmpdir(), `git-mcp-config-${Date.now()}-no-patterns.yaml`);
+    tempPaths.push(repoDir, configPath);
+
+    await fs.writeFile(configPath, `repositories:\n  - path: ${repoDir}\n`, "utf8");
+
+    await expect(loadConfig(configPath)).rejects.toThrow(
+      `repository '${repoDir}' must define allowed_branch_patterns directly or inherit them from top-level defaults`,
+    );
   });
 
   it("expands home-directory paths", async () => {


### PR DESCRIPTION
## Why
The config model already supports per-repository `allowed_branch_patterns` and `allow_draft_prs`, but larger setups end up repeating the same policy across many repo entries. Adding optional top-level defaults keeps the policy model narrow while making common branch and draft-PR settings easier to share.

This change resolves defaults once in the loader so the rest of the tool surface can keep operating on the same effective per-repo policy shape it uses today.

## Impact
Repositories can now inherit `allowed_branch_patterns`, `default_remote`, and `allow_draft_prs` from a top-level `defaults` block, while still overriding those fields per repo when needed. The main behavior change to watch is that each repo must still resolve to at least one effective branch pattern, so configs that omit both repo-level and top-level patterns will now fail fast.
