### PR TITLE
Add always-allowed branch patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,11 @@ Example:
 ```yaml
 defaults:
   allowed_branch_patterns:
-    - "^user/.*$"
+    - "^main$"
   allow_draft_prs: true
+
+always_allowed_branch_patterns:
+  - "^user/.*$"
 
 repositories:
   - path: ~/projects/codex-git-unleash-mcp
@@ -64,9 +67,11 @@ Notes:
 
 - `path` must be an absolute path or start with `~/`
 - top-level `defaults` are optional and may define `allowed_branch_patterns`, `default_remote`, and `allow_draft_prs`
+- top-level `always_allowed_branch_patterns` are optional and are appended to every repository's effective branch policy
 - repository values override top-level defaults field-by-field
+- `defaults.allowed_branch_patterns` are inherited or overridden, while `always_allowed_branch_patterns` are always added
 - branch patterns are full-match regexes against the current branch name
-- each repository must end up with at least one effective allowed branch pattern, either from the repo entry or inherited from `defaults`
+- each repository must end up with at least one effective allowed branch pattern, either from the repo entry, inherited `defaults`, or `always_allowed_branch_patterns`
 - `git_repo_policy` returns the configured branch patterns and related repository defaults for an allowlisted repository
 - `git_add`, `git_commit`, `git_push`, and `gh_pr_create_draft` require the current branch to match one of the configured patterns
 - `git_fetch` only requires the repository to be allowlisted, fetches from the resolved remote, and uses an explicit branch when provided or the detected base branch otherwise
@@ -189,7 +194,10 @@ If you want to branch from `main` but only allow mutations on personal feature b
 ```yaml
 defaults:
   allowed_branch_patterns:
-    - "^user/.*$"
+    - "^main$"
+
+always_allowed_branch_patterns:
+  - "^dm/.*$"
 
 repositories:
   - path: ~/projects/codex-git-unleash-mcp

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ defaults:
     - "^main$"
 
 always_allowed_branch_patterns:
-  - "^dm/.*$"
+  - "^user/.*$"
 
 repositories:
   - path: ~/projects/codex-git-unleash-mcp

--- a/src/config.ts
+++ b/src/config.ts
@@ -20,6 +20,7 @@ const repoPolicySchema = policyDefaultsSchema.extend({
 
 const configSchema = z.object({
   defaults: policyDefaultsSchema.optional(),
+  always_allowed_branch_patterns: z.array(z.string().min(1)).nonempty().optional(),
   repositories: z.array(repoPolicySchema),
 });
 
@@ -43,10 +44,13 @@ export async function loadConfig(configPath: string): Promise<Config> {
       throw new ConfigError(`duplicate configured repository path '${canonicalPath}'`);
     }
 
-    const patternSources = repo.allowed_branch_patterns ?? config.defaults?.allowed_branch_patterns;
-    if (!patternSources || patternSources.length === 0) {
+    const repoPatternSources = repo.allowed_branch_patterns ?? config.defaults?.allowed_branch_patterns ?? [];
+    const globalPatternSources = config.always_allowed_branch_patterns ?? [];
+    const patternSources = [...repoPatternSources, ...globalPatternSources];
+
+    if (patternSources.length === 0) {
       throw new ConfigError(
-        `repository '${repo.path}' must define allowed_branch_patterns directly or inherit them from top-level defaults`,
+        `repository '${repo.path}' must define allowed_branch_patterns directly, inherit them from top-level defaults, or rely on always_allowed_branch_patterns`,
       );
     }
 

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -44,7 +44,7 @@ describe("loadConfig", () => {
       [
         "defaults:",
         "  allowed_branch_patterns:",
-        '    - "^dm/.+$"',
+        '    - "^user/.+$"',
         "  default_remote: upstream",
         "  allow_draft_prs: false",
         "repositories:",
@@ -55,7 +55,7 @@ describe("loadConfig", () => {
 
     const config = await loadConfig(configPath);
 
-    expect(config.repositories[0]?.allowedBranchPatterns.map((pattern) => pattern.source)).toEqual(["^dm\\/.+$"]);
+    expect(config.repositories[0]?.allowedBranchPatterns.map((pattern) => pattern.source)).toEqual(["^user\\/.+$"]);
     expect(config.repositories[0]?.defaultRemote).toBe("upstream");
     expect(config.repositories[0]?.allowDraftPrs).toBe(false);
   });
@@ -69,7 +69,7 @@ describe("loadConfig", () => {
       configPath,
       [
         'always_allowed_branch_patterns:',
-        '  - "^dm/.+$"',
+        '  - "^user/.+$"',
         "repositories:",
         `  - path: ${repoDir}`,
         "    allowed_branch_patterns:",
@@ -82,7 +82,7 @@ describe("loadConfig", () => {
 
     expect(config.repositories[0]?.allowedBranchPatterns.map((pattern) => pattern.source)).toEqual([
       "^main$",
-      "^dm\\/.+$",
+      "^user\\/.+$",
     ]);
   });
 
@@ -96,7 +96,7 @@ describe("loadConfig", () => {
       [
         "defaults:",
         "  allowed_branch_patterns:",
-        '    - "^dm/.+$"',
+        '    - "^user/.+$"',
         "  default_remote: upstream",
         "  allow_draft_prs: false",
         "repositories:",
@@ -128,7 +128,7 @@ describe("loadConfig", () => {
         "  allowed_branch_patterns:",
         '    - "^main$"',
         'always_allowed_branch_patterns:',
-        '  - "^dm/.+$"',
+        '  - "^user/.+$"',
         "repositories:",
         `  - path: ${repoDir}`,
       ].join("\n"),
@@ -139,7 +139,7 @@ describe("loadConfig", () => {
 
     expect(config.repositories[0]?.allowedBranchPatterns.map((pattern) => pattern.source)).toEqual([
       "^main$",
-      "^dm\\/.+$",
+      "^user\\/.+$",
     ]);
   });
 
@@ -150,13 +150,13 @@ describe("loadConfig", () => {
 
     await fs.writeFile(
       configPath,
-      ['always_allowed_branch_patterns:', '  - "^dm/.+$"', "repositories:", `  - path: ${repoDir}`].join("\n"),
+      ['always_allowed_branch_patterns:', '  - "^user/.+$"', "repositories:", `  - path: ${repoDir}`].join("\n"),
       "utf8",
     );
 
     const config = await loadConfig(configPath);
 
-    expect(config.repositories[0]?.allowedBranchPatterns.map((pattern) => pattern.source)).toEqual(["^dm\\/.+$"]);
+    expect(config.repositories[0]?.allowedBranchPatterns.map((pattern) => pattern.source)).toEqual(["^user\\/.+$"]);
   });
 
   it("rejects repositories without effective branch patterns", async () => {

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -60,6 +60,32 @@ describe("loadConfig", () => {
     expect(config.repositories[0]?.allowDraftPrs).toBe(false);
   });
 
+  it("appends always-allowed branch patterns to repository policy", async () => {
+    const repoDir = await fs.mkdtemp(path.join(os.tmpdir(), "git-mcp-global-patterns-repo-"));
+    const configPath = path.join(os.tmpdir(), `git-mcp-config-${Date.now()}-global-patterns.yaml`);
+    tempPaths.push(repoDir, configPath);
+
+    await fs.writeFile(
+      configPath,
+      [
+        'always_allowed_branch_patterns:',
+        '  - "^dm/.+$"',
+        "repositories:",
+        `  - path: ${repoDir}`,
+        "    allowed_branch_patterns:",
+        '      - "^main$"',
+      ].join("\n"),
+      "utf8",
+    );
+
+    const config = await loadConfig(configPath);
+
+    expect(config.repositories[0]?.allowedBranchPatterns.map((pattern) => pattern.source)).toEqual([
+      "^main$",
+      "^dm\\/.+$",
+    ]);
+  });
+
   it("lets repositories override top-level defaults", async () => {
     const repoDir = await fs.mkdtemp(path.join(os.tmpdir(), "git-mcp-override-repo-"));
     const configPath = path.join(os.tmpdir(), `git-mcp-config-${Date.now()}-override.yaml`);
@@ -90,6 +116,49 @@ describe("loadConfig", () => {
     expect(config.repositories[0]?.allowDraftPrs).toBe(true);
   });
 
+  it("appends always-allowed branch patterns to inherited defaults", async () => {
+    const repoDir = await fs.mkdtemp(path.join(os.tmpdir(), "git-mcp-defaults-plus-global-repo-"));
+    const configPath = path.join(os.tmpdir(), `git-mcp-config-${Date.now()}-defaults-plus-global.yaml`);
+    tempPaths.push(repoDir, configPath);
+
+    await fs.writeFile(
+      configPath,
+      [
+        "defaults:",
+        "  allowed_branch_patterns:",
+        '    - "^main$"',
+        'always_allowed_branch_patterns:',
+        '  - "^dm/.+$"',
+        "repositories:",
+        `  - path: ${repoDir}`,
+      ].join("\n"),
+      "utf8",
+    );
+
+    const config = await loadConfig(configPath);
+
+    expect(config.repositories[0]?.allowedBranchPatterns.map((pattern) => pattern.source)).toEqual([
+      "^main$",
+      "^dm\\/.+$",
+    ]);
+  });
+
+  it("accepts repositories that only rely on always-allowed branch patterns", async () => {
+    const repoDir = await fs.mkdtemp(path.join(os.tmpdir(), "git-mcp-global-only-repo-"));
+    const configPath = path.join(os.tmpdir(), `git-mcp-config-${Date.now()}-global-only.yaml`);
+    tempPaths.push(repoDir, configPath);
+
+    await fs.writeFile(
+      configPath,
+      ['always_allowed_branch_patterns:', '  - "^dm/.+$"', "repositories:", `  - path: ${repoDir}`].join("\n"),
+      "utf8",
+    );
+
+    const config = await loadConfig(configPath);
+
+    expect(config.repositories[0]?.allowedBranchPatterns.map((pattern) => pattern.source)).toEqual(["^dm\\/.+$"]);
+  });
+
   it("rejects repositories without effective branch patterns", async () => {
     const repoDir = await fs.mkdtemp(path.join(os.tmpdir(), "git-mcp-no-patterns-repo-"));
     const configPath = path.join(os.tmpdir(), `git-mcp-config-${Date.now()}-no-patterns.yaml`);
@@ -98,7 +167,7 @@ describe("loadConfig", () => {
     await fs.writeFile(configPath, `repositories:\n  - path: ${repoDir}\n`, "utf8");
 
     await expect(loadConfig(configPath)).rejects.toThrow(
-      `repository '${repoDir}' must define allowed_branch_patterns directly or inherit them from top-level defaults`,
+      `repository '${repoDir}' must define allowed_branch_patterns directly, inherit them from top-level defaults, or rely on always_allowed_branch_patterns`,
     );
   });
 

--- a/tests/gitRepoPolicy.test.ts
+++ b/tests/gitRepoPolicy.test.ts
@@ -9,7 +9,7 @@ describe("getGitRepoPolicy", () => {
       path: "/tmp/repo",
       canonicalPath: "/private/tmp/repo",
       worktreePath: "/private/tmp/repo",
-      allowedBranchPatterns: [/^dm\/.*$/, /^feature\/[a-z0-9._-]+$/],
+      allowedBranchPatterns: [/^user\/.*$/, /^feature\/[a-z0-9._-]+$/],
       defaultRemote: "origin",
       allowDraftPrs: true,
     };
@@ -17,7 +17,7 @@ describe("getGitRepoPolicy", () => {
     expect(getGitRepoPolicy(repo)).toEqual({
       path: "/tmp/repo",
       canonicalPath: "/private/tmp/repo",
-      allowedBranchPatterns: ["^dm\\/.*$", "^feature\\/[a-z0-9._-]+$"],
+      allowedBranchPatterns: ["^user\\/.*$", "^feature\\/[a-z0-9._-]+$"],
       defaultRemote: "origin",
       allowDraftPrs: true,
     });


### PR DESCRIPTION
## Why
The earlier config-defaults change made shared replacement defaults possible, but it still did not cover the case where one narrow personal branch pattern should be permitted everywhere without replacing each repository's local policy. That additive use case needs different semantics from `defaults.allowed_branch_patterns`.

This change adds an explicit top-level `always_allowed_branch_patterns` layer so global personal-branch access can be modeled without broadening repository-specific replacement defaults.

## Impact
Repositories can now define a narrow additive branch-pattern policy that is appended to every repo's effective allowed-branch set, while keeping repo-level and inherited default patterns explicit. The main behavior change is that a repository can now satisfy the branch-policy requirement via `always_allowed_branch_patterns` alone, so operators should keep those patterns intentionally narrow.
