### PR TITLE
Add constrained git_worktree_add MCP tool

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,15 +4,17 @@
 
 For this repository, the following end-to-end workflow is required for repository changes:
 
-1. inspect the repository policy and create and switch to a new branch from the detected upstream base
+1. inspect the repository policy and create a new linked worktree on a new branch with `git_unleash.git_worktree_add`
 2. do planning and coding work
 3. commit changes (prefer smaller, targeted commits)
 4. push the current branch
 5. create a draft PR
 6. address PR review comments and iterate as needed, preferably one comment at a time or grouped by theme
 
-Do not begin planning edits or making repository changes on the current branch before step 1 is complete.
+Do not begin planning edits or making repository changes before step 1 is complete.
 
-Before creating a development branch, call `git_unleash.git_repo_policy` and choose a branch name that matches the configured `allowed_branch_patterns`. Do not assume a default prefix or reuse a prefix from another repository.
+Before creating a development worktree, call `git_unleash.git_repo_policy` and choose a `new_branch` value that matches the configured `allowed_branch_patterns`. Use that `new_branch` with `git_unleash.git_worktree_add`, and provide an explicit absolute worktree path outside the repository root. Do not assume a default prefix or reuse a prefix from another repository.
+
+Note: other repositories may prefer `git_unleash.git_branch_create_and_switch` instead, especially very large repositories where creating an additional linked worktree is too expensive for the task.
 
 The Git and GitHub operations for the steps above must be performed using the `git_unleash` MCP.

--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -60,6 +60,7 @@ src/
     gitAdd.ts
     gitCommit.ts
     gitFetch.ts
+    gitWorktreeAdd.ts
     gitPush.ts
     gitBranchCreateAndSwitch.ts
     gitBranchSwitch.ts
@@ -327,6 +328,30 @@ Output guidance:
 - return the resolved remote and branch
 - push the current branch to the same-named remote branch only in the initial version
 
+### `git_worktree_add`
+
+Validation:
+
+- repository path is required
+- repository must be allowlisted
+- `path` must be a non-empty absolute path outside the repository root
+- `new_branch` must be non-empty after trimming
+- `new_branch` must match at least one configured allowed branch pattern
+- `new_branch` must not already exist locally
+- resolve the remote by preferring configured `default_remote`, then the current branch remote, then `origin`
+- if `branch` is provided, treat it as the upstream base branch name
+- otherwise resolve the base branch from remote HEAD first, with GitHub default-branch lookup as a fallback
+
+Execution:
+
+- fetch the upstream base branch from the detected remote
+- create a linked worktree at the validated absolute path
+- create and check out the new local branch there from `refs/remotes/<remote>/<base>`
+
+Output guidance:
+
+- return the created branch, resolved remote, resolved base branch, and resolved worktree path
+
 ### `git_branch_create_and_switch`
 
 Validation:
@@ -466,6 +491,7 @@ Cover:
 - `git_add` path escaping denied
 - successful add and commit
 - empty commit denied
+- successful linked worktree creation from fetched upstream base
 - successful branch creation and switch from fetched upstream base
 - duplicate branch creation denied
 - clean-worktree branch switch succeeds
@@ -492,6 +518,7 @@ Live GitHub integration tests can be deferred until later.
 - `git_add`
 - `git_commit`
 - `git_fetch`
+- `git_worktree_add`
 - `git_push`
 - `git_branch_create_and_switch`
 - `git_branch_switch`

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Current tool surface:
 - `git_add`
 - `git_commit`
 - `git_fetch`
+- `git_worktree_add`
 - `git_push`
 - `git_branch_create_and_switch`
 - `git_branch_switch`
@@ -75,6 +76,7 @@ Notes:
 - `git_repo_policy` returns the configured branch patterns and related repository defaults for an allowlisted repository
 - `git_add`, `git_commit`, `git_push`, and `gh_pr_create_draft` require the current branch to match one of the configured patterns
 - `git_fetch` only requires the repository to be allowlisted, fetches from the resolved remote, and uses an explicit branch when provided or the detected base branch otherwise
+- `git_worktree_add` requires an explicit absolute target path outside the repository root, validates the requested new branch name against `allowed_branch_patterns`, and creates a linked worktree from an explicit or detected upstream base branch
 - `git_branch_create_and_switch` and `git_branch_switch` require a clean worktree
 - `git_branch_create_and_switch` also requires the requested new branch name to match `allowed_branch_patterns`
 - remote resolution prefers configured `default_remote` when present and valid, then the current branch's remote, then `origin`
@@ -87,11 +89,12 @@ The intended happy path is:
 
 1. Call `git_repo_policy` or `git_status` to inspect the allowlisted repository.
 2. Before creating a branch, use `git_repo_policy` to confirm the configured `allowed_branch_patterns`, then choose a new branch name that matches that policy.
-3. Call `git_branch_create_and_switch` to branch from an explicit or detected upstream base when you need a new local branch.
-4. Call `git_add` with explicit repository-relative paths.
-5. Call `git_commit` with a normal commit message.
-6. Call `git_push` to push the current branch to the resolved remote.
-7. Call `gh_pr_create_draft` to open a draft PR against an explicit base or the detected default base branch.
+3. Call `git_branch_create_and_switch` to branch from an explicit or detected upstream base when you need a new local branch in the current worktree.
+4. Call `git_worktree_add` when you need a separate linked worktree on a new allowed branch at an explicit absolute path outside the repository root.
+5. Call `git_add` with explicit repository-relative paths.
+6. Call `git_commit` with a normal commit message.
+7. Call `git_push` to push the current branch to the resolved remote.
+8. Call `gh_pr_create_draft` to open a draft PR against an explicit base or the detected default base branch.
 
 Each step stays inside a fixed policy boundary. There is no arbitrary checkout, no arbitrary push refspec, no amend flow, and no non-draft PR creation.
 
@@ -170,6 +173,7 @@ Once registered, Codex should be able to use:
 - `git_add` for repository-relative paths inside an allowlisted repository; it rejects absolute paths and repository-escaping paths like `../x`
 - `git_commit` with a normal commit message on an allowed branch; it rejects empty commit messages and empty commits
 - `git_fetch` to fetch a plain branch name from the detected remote; it does not allow arbitrary fetch arguments or refspecs and uses an explicit branch when provided or the detected base branch otherwise
+- `git_worktree_add` to create a linked worktree for a new allowed branch at an explicit absolute path outside the repository root; it fetches the explicit or detected base branch first and does not allow arbitrary refs
 - `git_branch_create_and_switch` to create a local branch from an explicit or detected upstream base and switch to it; it rejects requested branch names that do not match the configured allowed branch patterns
 - `git_branch_switch` to switch to an existing local branch when the worktree is clean; it does not create branches or allow detached checkouts
 - `git_push` to push the current branch to the detected remote; it only pushes `HEAD` to `refs/heads/<current-branch>` and does not allow arbitrary refspecs or force-like behavior
@@ -181,9 +185,9 @@ Mutating tools reject detached HEAD.
 
 Some operations resolve defaults at runtime instead of requiring everything to be pinned in config.
 
-- `git_fetch`, `git_push`, `git_branch_create_and_switch`, and `gh_pr_create_draft` resolve the remote by preferring configured `default_remote`, then the current branch remote, then `origin`
-- `git_fetch`, `git_branch_create_and_switch`, and `gh_pr_create_draft` accept an explicit branch or base input
-- `git_fetch`, `git_branch_create_and_switch`, and `gh_pr_create_draft` resolve their default branch or base by preferring the remote HEAD branch and falling back to the GitHub repository default branch when no explicit input is provided
+- `git_fetch`, `git_push`, `git_worktree_add`, `git_branch_create_and_switch`, and `gh_pr_create_draft` resolve the remote by preferring configured `default_remote`, then the current branch remote, then `origin`
+- `git_fetch`, `git_worktree_add`, `git_branch_create_and_switch`, and `gh_pr_create_draft` accept an explicit branch or base input
+- `git_fetch`, `git_worktree_add`, `git_branch_create_and_switch`, and `gh_pr_create_draft` resolve their default branch or base by preferring the remote HEAD branch and falling back to the GitHub repository default branch when no explicit input is provided
 
 This keeps the tools constrained while still working across repositories that use different default branches or remotes.
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -68,7 +68,8 @@ At minimum, mutating operations include:
 
 Branch-workflow exception:
 
-- `git_branch_create_and_switch` and `git_branch_switch` may be allowed without current-branch pattern checks as long as they preserve the clean-worktree and constrained-ref safety rules
+- `git_worktree_add`, `git_branch_create_and_switch`, and `git_branch_switch` may be allowed without current-branch pattern checks as long as they preserve the clean-worktree or constrained-worktree and ref safety rules
+- `git_worktree_add` must validate the requested `new_branch` name against the configured allowed branch patterns before creating the linked worktree and branch
 - `git_branch_create_and_switch` must still validate the requested `new_branch` name against the configured allowed branch patterns before creating and switching to it
 
 Read-only operations such as `git_repo_policy` and `git_status` may still require repository allowlisting, but do not necessarily need branch checks unless implementation simplicity makes a uniform check preferable.
@@ -114,6 +115,7 @@ The server may expose structured tools for operations such as:
 - repository inspection and policy inspection
 - constrained staging and commit creation
 - constrained branch creation and branch switching
+- constrained linked worktree creation
 - constrained remote synchronization
 - constrained GitHub pull request creation
 

--- a/src/auth/pathValidation.ts
+++ b/src/auth/pathValidation.ts
@@ -1,3 +1,4 @@
+import fs from "node:fs/promises";
 import path from "node:path";
 
 import { PathValidationError } from "../errors.js";
@@ -8,6 +9,30 @@ export function validateRepoRelativePaths(repoRoot: string, inputPaths: string[]
   }
 
   return inputPaths.map((inputPath) => validateRepoRelativePath(repoRoot, inputPath));
+}
+
+export async function validateWorktreePath(repoRoot: string, inputPath: string): Promise<string> {
+  if (!inputPath.trim()) {
+    throw new PathValidationError("worktree path must be non-empty");
+  }
+
+  if (!path.isAbsolute(inputPath)) {
+    throw new PathValidationError(`worktree path '${inputPath}' must be absolute`);
+  }
+
+  const canonicalRepoRoot = await fs.realpath(repoRoot);
+  const resolvedPath = path.resolve(inputPath);
+  const canonicalWorktreePath = await canonicalizeProspectivePath(resolvedPath);
+  const relativeToRoot = path.relative(canonicalRepoRoot, canonicalWorktreePath);
+  if (
+    relativeToRoot === "" ||
+    relativeToRoot === "." ||
+    (!relativeToRoot.startsWith(`..${path.sep}`) && relativeToRoot !== ".." && !path.isAbsolute(relativeToRoot))
+  ) {
+    throw new PathValidationError(`worktree path '${inputPath}' must be outside the repository root`);
+  }
+
+  return canonicalWorktreePath;
 }
 
 function validateRepoRelativePath(repoRoot: string, inputPath: string): string {
@@ -40,4 +65,24 @@ function validateRepoRelativePath(repoRoot: string, inputPath: string): string {
   }
 
   return relativeToRoot === "" ? "." : relativeToRoot;
+}
+
+async function canonicalizeProspectivePath(inputPath: string): Promise<string> {
+  const parts: string[] = [];
+  let currentPath = inputPath;
+
+  while (true) {
+    try {
+      const canonicalBase = await fs.realpath(currentPath);
+      return path.join(canonicalBase, ...parts.reverse());
+    } catch {
+      const parentPath = path.dirname(currentPath);
+      if (parentPath === currentPath) {
+        throw new PathValidationError(`worktree path '${inputPath}' could not be resolved`);
+      }
+
+      parts.push(path.basename(currentPath));
+      currentPath = parentPath;
+    }
+  }
 }

--- a/src/exec/git.ts
+++ b/src/exec/git.ts
@@ -26,6 +26,10 @@ export function gitCreateBranchArgs(newBranch: string, startPoint: string): stri
   return ["branch", newBranch, startPoint];
 }
 
+export function gitWorktreeAddArgs(worktreePath: string, newBranch: string, startPoint: string): string[] {
+  return ["worktree", "add", "-b", newBranch, worktreePath, startPoint];
+}
+
 export function gitSwitchBranchArgs(branch: string): string[] {
   return ["checkout", branch];
 }
@@ -129,6 +133,19 @@ export async function createBranch(cwd: string, newBranch: string, startPoint: s
     cwd,
     command: "git",
     argv: gitCreateBranchArgs(newBranch, startPoint),
+  });
+}
+
+export async function addWorktree(
+  cwd: string,
+  worktreePath: string,
+  newBranch: string,
+  startPoint: string,
+): Promise<void> {
+  await runCommand({
+    cwd,
+    command: "git",
+    argv: gitWorktreeAddArgs(worktreePath, newBranch, startPoint),
   });
 }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -13,6 +13,7 @@ import { gitFetch } from "./tools/gitFetch.js";
 import { gitPush } from "./tools/gitPush.js";
 import { getGitRepoPolicy } from "./tools/gitRepoPolicy.js";
 import { getGitStatus } from "./tools/gitStatus.js";
+import { gitWorktreeAdd } from "./tools/gitWorktreeAdd.js";
 
 export function createServer(config: Config): McpServer {
   const server = new McpServer({
@@ -163,6 +164,30 @@ export function createServer(config: Config): McpServer {
     async ({ repo_path, branch }) => {
       const repo = await resolveAllowedRepo(config, repo_path);
       const result = await gitFetch(repo, { branch });
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(result, null, 2),
+          },
+        ],
+      };
+    },
+  );
+
+  server.tool(
+    "git_worktree_add",
+    "Create a linked worktree at an explicit absolute path for a new local branch in an allowlisted repository. This tool mutates repository state, validates the requested branch name against configured full-match patterns, fetches the chosen base branch first, and rejects worktree paths inside the repository root.",
+    {
+      repo_path: z.string().min(1),
+      path: z.string().min(1),
+      new_branch: z.string(),
+      branch: z.string().min(1).optional(),
+    },
+    async ({ repo_path, path, new_branch, branch }) => {
+      const repo = await resolveAllowedRepo(config, repo_path);
+      const result = await gitWorktreeAdd(repo, { path, newBranch: new_branch, branch });
 
       return {
         content: [

--- a/src/tools/gitWorktreeAdd.ts
+++ b/src/tools/gitWorktreeAdd.ts
@@ -1,0 +1,42 @@
+import { requireAllowedBranchName } from "../auth/branchAuth.js";
+import { validateWorktreePath } from "../auth/pathValidation.js";
+import { BranchAlreadyExistsError, EmptyBranchNameError } from "../errors.js";
+import { addWorktree, branchExists, fetchBranch } from "../exec/git.js";
+import type { RepoPolicy } from "../types/config.js";
+import { resolveRepoBaseBranch, resolveRepoRemote } from "./runtimeDefaults.js";
+
+export type GitWorktreeAddResult = {
+  branch: string;
+  remote: string;
+  base: string;
+  path: string;
+};
+
+export async function gitWorktreeAdd(
+  repo: RepoPolicy,
+  input: { path: string; newBranch: string; branch?: string },
+): Promise<GitWorktreeAddResult> {
+  const normalizedBranch = input.newBranch.trim();
+  if (!normalizedBranch) {
+    throw new EmptyBranchNameError();
+  }
+  requireAllowedBranchName(repo, normalizedBranch);
+
+  if (await branchExists(repo.worktreePath, normalizedBranch)) {
+    throw new BranchAlreadyExistsError(normalizedBranch, repo.worktreePath);
+  }
+
+  const worktreePath = await validateWorktreePath(repo.canonicalPath, input.path);
+  const remote = await resolveRepoRemote(repo);
+  const base = input.branch?.trim() || (await resolveRepoBaseBranch(repo, remote));
+
+  await fetchBranch(repo.worktreePath, remote, base);
+  await addWorktree(repo.worktreePath, worktreePath, normalizedBranch, `refs/remotes/${remote}/${base}`);
+
+  return {
+    branch: normalizedBranch,
+    remote,
+    base,
+    path: worktreePath,
+  };
+}

--- a/tests/gitArgs.test.ts
+++ b/tests/gitArgs.test.ts
@@ -10,6 +10,7 @@ import {
   gitRemoteGetUrlArgs,
   gitRemoteHeadArgs,
   gitSwitchBranchArgs,
+  gitWorktreeAddArgs,
 } from "../src/exec/git.js";
 
 describe("git argument builders", () => {
@@ -44,6 +45,17 @@ describe("git argument builders", () => {
 
   it("builds constrained git branch switch arguments", () => {
     expect(gitSwitchBranchArgs("feature/test-pr")).toEqual(["checkout", "feature/test-pr"]);
+  });
+
+  it("builds constrained git worktree add arguments", () => {
+    expect(gitWorktreeAddArgs("/tmp/worktree", "feature/test-pr", "refs/remotes/origin/main")).toEqual([
+      "worktree",
+      "add",
+      "-b",
+      "feature/test-pr",
+      "/tmp/worktree",
+      "refs/remotes/origin/main",
+    ]);
   });
 
   it("builds constrained git remote resolution arguments", () => {

--- a/tests/gitBranchCreateAndSwitch.test.ts
+++ b/tests/gitBranchCreateAndSwitch.test.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 
 import { afterEach, describe, expect, it } from "vitest";
@@ -187,8 +188,9 @@ describe("gitBranchCreateAndSwitch", () => {
   it("creates and switches the branch in a linked worktree", async () => {
     const { repoDir, repo } = await createTempGitRepo();
     const remoteDir = await createTempBareGitRepo();
-    const worktreeDir = path.join(path.dirname(repoDir), "git-mcp-worktree-linked");
-    tempPaths.push(repoDir, remoteDir, worktreeDir);
+    const worktreeParentDir = await fs.mkdtemp(path.join(os.tmpdir(), "git-mcp-worktree-parent-"));
+    const worktreeDir = path.join(worktreeParentDir, "linked");
+    tempPaths.push(repoDir, remoteDir, worktreeParentDir);
 
     await runCommand({ cwd: repoDir, command: "git", argv: ["remote", "add", "origin", remoteDir] });
     await fs.writeFile(path.join(repoDir, "README.md"), "hello\n", "utf8");

--- a/tests/gitFetch.test.ts
+++ b/tests/gitFetch.test.ts
@@ -10,7 +10,7 @@ import { gitAdd } from "../src/tools/gitAdd.js";
 import { gitCommit } from "../src/tools/gitCommit.js";
 import { gitFetch } from "../src/tools/gitFetch.js";
 import { gitPush } from "../src/tools/gitPush.js";
-import { createTempBareGitRepo, createTempGitRepo } from "./helpers.js";
+import { configureTestGitRepo, createTempBareGitRepo, createTempGitRepo } from "./helpers.js";
 
 const tempPaths: string[] = [];
 
@@ -33,8 +33,7 @@ describe("gitFetch", () => {
     await runCommand({ cwd: remoteDir, command: "git", argv: ["symbolic-ref", "HEAD", "refs/heads/main"] });
 
     await runCommand({ cwd: updaterDir, command: "git", argv: ["clone", remoteDir, "."] });
-    await runCommand({ cwd: updaterDir, command: "git", argv: ["config", "user.name", "Codex Test"] });
-    await runCommand({ cwd: updaterDir, command: "git", argv: ["config", "user.email", "codex@example.com"] });
+    await configureTestGitRepo(updaterDir);
     await fs.writeFile(path.join(updaterDir, "CHANGELOG.md"), "update\n", "utf8");
     await runCommand({ cwd: updaterDir, command: "git", argv: ["add", "CHANGELOG.md"] });
     await runCommand({ cwd: updaterDir, command: "git", argv: ["commit", "-m", "remote update"] });

--- a/tests/gitStatus.test.ts
+++ b/tests/gitStatus.test.ts
@@ -6,7 +6,7 @@ import { afterEach, describe, expect, it } from "vitest";
 
 import { getGitStatus } from "../src/tools/gitStatus.js";
 import { runCommand } from "../src/exec/run.js";
-import { createLinkedWorktree, createTempGitRepo } from "./helpers.js";
+import { configureTestGitRepo, createLinkedWorktree, createTempGitRepo } from "./helpers.js";
 
 const tempPaths: string[] = [];
 
@@ -34,6 +34,7 @@ describe("getGitStatus", () => {
 
     await fs.writeFile(path.join(repoDir, "README.md"), "hello\n", "utf8");
     await runCommand({ cwd: repoDir, command: "git", argv: ["add", "README.md"] });
+    await configureTestGitRepo(repoDir);
     await runCommand({ cwd: repoDir, command: "git", argv: ["commit", "-m", "init"] });
 
     const linkedWorktree = await createLinkedWorktree(repoDir, worktreeDir);

--- a/tests/gitWorktreeAdd.test.ts
+++ b/tests/gitWorktreeAdd.test.ts
@@ -1,0 +1,164 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { BranchAlreadyExistsError, BranchNameNotAllowedError, PathValidationError } from "../src/errors.js";
+import { getCurrentBranch } from "../src/exec/git.js";
+import { runCommand } from "../src/exec/run.js";
+import { gitAdd } from "../src/tools/gitAdd.js";
+import { gitCommit } from "../src/tools/gitCommit.js";
+import { gitPush } from "../src/tools/gitPush.js";
+import { gitWorktreeAdd } from "../src/tools/gitWorktreeAdd.js";
+import { createTempBareGitRepo, createTempGitRepo } from "./helpers.js";
+
+const tempPaths: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempPaths.splice(0).map((tempPath) => fs.rm(tempPath, { force: true, recursive: true })));
+});
+
+describe("gitWorktreeAdd", () => {
+  it("creates a linked worktree for a new branch from the detected upstream base", async () => {
+    const { repoDir, repo } = await createTempGitRepo();
+    const remoteDir = await createTempBareGitRepo();
+    const worktreeParentDir = await fs.mkdtemp(path.join(os.tmpdir(), "git-mcp-worktree-add-parent-"));
+    const worktreeDir = path.join(worktreeParentDir, "linked");
+    tempPaths.push(repoDir, remoteDir, worktreeParentDir);
+    const expectedWorktreePath = path.join(await fs.realpath(worktreeParentDir), "linked");
+
+    await runCommand({ cwd: repoDir, command: "git", argv: ["remote", "add", "origin", remoteDir] });
+    await fs.writeFile(path.join(repoDir, "README.md"), "hello\n", "utf8");
+    await gitAdd(repo, ["README.md"]);
+    await gitCommit(repo, "add readme");
+    await gitPush(repo, "main");
+    await runCommand({
+      cwd: remoteDir,
+      command: "git",
+      argv: ["symbolic-ref", "HEAD", "refs/heads/main"],
+    });
+
+    const result = await gitWorktreeAdd(
+      {
+        ...repo,
+        allowedBranchPatterns: [/^feature\/.+$/],
+      },
+      {
+        path: worktreeDir,
+        newBranch: "feature/from-worktree-add",
+      },
+    );
+
+    await expect(getCurrentBranch(repoDir)).resolves.toBe("main");
+    await expect(getCurrentBranch(result.path)).resolves.toBe("feature/from-worktree-add");
+    expect(result).toEqual({
+      branch: "feature/from-worktree-add",
+      remote: "origin",
+      base: "main",
+      path: expectedWorktreePath,
+    });
+  });
+
+  it("uses an explicit upstream branch when provided", async () => {
+    const { repoDir, repo } = await createTempGitRepo();
+    const remoteDir = await createTempBareGitRepo();
+    const worktreeParentDir = await fs.mkdtemp(path.join(os.tmpdir(), "git-mcp-worktree-add-explicit-parent-"));
+    const worktreeDir = path.join(worktreeParentDir, "linked");
+    tempPaths.push(repoDir, remoteDir, worktreeParentDir);
+    const expectedWorktreePath = path.join(await fs.realpath(worktreeParentDir), "linked");
+
+    await runCommand({ cwd: repoDir, command: "git", argv: ["remote", "add", "origin", remoteDir] });
+    await fs.writeFile(path.join(repoDir, "README.md"), "hello\n", "utf8");
+    await gitAdd(repo, ["README.md"]);
+    await gitCommit(repo, "add readme");
+    await gitPush(repo, "main");
+    await runCommand({
+      cwd: remoteDir,
+      command: "git",
+      argv: ["symbolic-ref", "HEAD", "refs/heads/main"],
+    });
+
+    await runCommand({ cwd: repoDir, command: "git", argv: ["checkout", "-b", "release"] });
+    await fs.writeFile(path.join(repoDir, "RELEASE.md"), "release\n", "utf8");
+    await gitAdd(repo, ["RELEASE.md"]);
+    await gitCommit(repo, "add release notes");
+    await gitPush(repo, "release");
+    await runCommand({ cwd: repoDir, command: "git", argv: ["checkout", "main"] });
+
+    const result = await gitWorktreeAdd(repo, {
+      path: worktreeDir,
+      newBranch: "feature/from-release-worktree",
+      branch: "release",
+    });
+
+    await expect(getCurrentBranch(result.path)).resolves.toBe("feature/from-release-worktree");
+    expect(result).toEqual({
+      branch: "feature/from-release-worktree",
+      remote: "origin",
+      base: "release",
+      path: expectedWorktreePath,
+    });
+  });
+
+  it("rejects branch names that do not match allowed patterns", async () => {
+    const { repoDir, repo } = await createTempGitRepo();
+    tempPaths.push(repoDir);
+
+    await expect(
+      gitWorktreeAdd(
+        {
+          ...repo,
+          allowedBranchPatterns: [/^feature\/.+$/],
+        },
+        {
+          path: "/tmp/git-mcp-disallowed-worktree",
+          newBranch: "dm/disallowed",
+        },
+      ),
+    ).rejects.toBeInstanceOf(BranchNameNotAllowedError);
+  });
+
+  it("rejects duplicate local branch names", async () => {
+    const { repoDir, repo } = await createTempGitRepo();
+    const remoteDir = await createTempBareGitRepo();
+    tempPaths.push(repoDir, remoteDir);
+
+    await runCommand({ cwd: repoDir, command: "git", argv: ["remote", "add", "origin", remoteDir] });
+    await fs.writeFile(path.join(repoDir, "README.md"), "hello\n", "utf8");
+    await gitAdd(repo, ["README.md"]);
+    await gitCommit(repo, "add readme");
+    await gitPush(repo, "main");
+    await runCommand({
+      cwd: remoteDir,
+      command: "git",
+      argv: ["symbolic-ref", "HEAD", "refs/heads/main"],
+    });
+    await runCommand({ cwd: repoDir, command: "git", argv: ["branch", "feature/existing"] });
+
+    await expect(
+      gitWorktreeAdd(
+        {
+          ...repo,
+          allowedBranchPatterns: [/^feature\/.+$/],
+        },
+        {
+          path: "/tmp/git-mcp-existing-branch-worktree",
+          newBranch: "feature/existing",
+        },
+      ),
+    ).rejects.toBeInstanceOf(BranchAlreadyExistsError);
+  });
+
+  it("rejects worktree paths inside the repository root", async () => {
+    const { repoDir, repo } = await createTempGitRepo();
+    tempPaths.push(repoDir);
+
+    await expect(
+      gitWorktreeAdd(repo, {
+        path: path.join(repoDir, "nested-worktree"),
+        newBranch: "feature/inside-repo",
+      }),
+    ).rejects.toBeInstanceOf(PathValidationError);
+  });
+});

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -9,8 +9,7 @@ export async function createTempGitRepo(): Promise<{ repoDir: string; repo: Repo
   const repoDir = await fs.mkdtemp(path.join(os.tmpdir(), "git-mcp-repo-"));
 
   await runCommand({ cwd: repoDir, command: "git", argv: ["init", "--initial-branch=main"] });
-  await runCommand({ cwd: repoDir, command: "git", argv: ["config", "user.name", "Codex Test"] });
-  await runCommand({ cwd: repoDir, command: "git", argv: ["config", "user.email", "codex@example.com"] });
+  await configureTestGitRepo(repoDir);
 
   return {
     repoDir,
@@ -28,6 +27,12 @@ export async function createTempBareGitRepo(): Promise<string> {
   const repoDir = await fs.mkdtemp(path.join(os.tmpdir(), "git-mcp-remote-"));
   await runCommand({ cwd: repoDir, command: "git", argv: ["init", "--bare"] });
   return repoDir;
+}
+
+export async function configureTestGitRepo(repoDir: string): Promise<void> {
+  await runCommand({ cwd: repoDir, command: "git", argv: ["config", "user.name", "Codex Test"] });
+  await runCommand({ cwd: repoDir, command: "git", argv: ["config", "user.email", "codex@example.com"] });
+  await runCommand({ cwd: repoDir, command: "git", argv: ["config", "commit.gpgsign", "false"] });
 }
 
 export async function createLinkedWorktree(repoDir: string, worktreeDir: string): Promise<string> {

--- a/tests/pathValidation.test.ts
+++ b/tests/pathValidation.test.ts
@@ -1,9 +1,17 @@
+import fs from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 
 import { PathValidationError } from "../src/errors.js";
-import { validateRepoRelativePaths } from "../src/auth/pathValidation.js";
+import { validateRepoRelativePaths, validateWorktreePath } from "../src/auth/pathValidation.js";
+
+const tempPaths: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempPaths.splice(0).map((tempPath) => fs.rm(tempPath, { force: true, recursive: true })));
+});
 
 describe("validateRepoRelativePaths", () => {
   it("accepts plain repository-relative paths", () => {
@@ -19,5 +27,31 @@ describe("validateRepoRelativePaths", () => {
 
   it("rejects traversal outside the repository", () => {
     expect(() => validateRepoRelativePaths("/repo", ["../secret"])).toThrowError(PathValidationError);
+  });
+
+  it("accepts absolute worktree paths outside the repository root", async () => {
+    const repoRoot = await fs.mkdtemp(path.join(os.tmpdir(), "git-mcp-path-root-"));
+    const worktreeParent = await fs.mkdtemp(path.join(os.tmpdir(), "git-mcp-worktree-parent-"));
+    const worktreePath = path.join(worktreeParent, "linked");
+    tempPaths.push(repoRoot, worktreeParent);
+    const canonicalParent = await fs.realpath(worktreeParent);
+
+    await expect(validateWorktreePath(repoRoot, worktreePath)).resolves.toBe(path.join(canonicalParent, "linked"));
+  });
+
+  it("rejects relative worktree paths", async () => {
+    const repoRoot = await fs.mkdtemp(path.join(os.tmpdir(), "git-mcp-path-root-"));
+    tempPaths.push(repoRoot);
+
+    await expect(validateWorktreePath(repoRoot, "tmp/worktree")).rejects.toBeInstanceOf(PathValidationError);
+  });
+
+  it("rejects worktree paths inside the repository root", async () => {
+    const repoRoot = await fs.mkdtemp(path.join(os.tmpdir(), "git-mcp-path-root-"));
+    tempPaths.push(repoRoot);
+
+    await expect(validateWorktreePath(repoRoot, path.join(repoRoot, "worktrees/feature"))).rejects.toBeInstanceOf(
+      PathValidationError,
+    );
   });
 });

--- a/tests/repoAuth.test.ts
+++ b/tests/repoAuth.test.ts
@@ -8,7 +8,7 @@ import { resolveAllowedRepo } from "../src/auth/repoAuth.js";
 import { RepoNotAllowedError } from "../src/errors.js";
 import { runCommand } from "../src/exec/run.js";
 import type { Config } from "../src/types/config.js";
-import { createLinkedWorktree, createTempGitRepo } from "./helpers.js";
+import { configureTestGitRepo, createLinkedWorktree, createTempGitRepo } from "./helpers.js";
 
 const tempPaths: string[] = [];
 
@@ -43,6 +43,7 @@ describe("resolveAllowedRepo", () => {
 
     await fs.writeFile(path.join(repoDir, "README.md"), "hello\n", "utf8");
     await runCommand({ cwd: repoDir, command: "git", argv: ["add", "README.md"] });
+    await configureTestGitRepo(repoDir);
     await runCommand({ cwd: repoDir, command: "git", argv: ["commit", "-m", "init"] });
 
     const linkedWorktree = await createLinkedWorktree(repoDir, worktreeDir);


### PR DESCRIPTION
## Why
This repository now implements a dedicated `git_worktree_add` MCP tool, but the repository instructions also needed to reflect that setup path so agents choose the intended workflow here. Adding the tool without updating the local workflow guidance would leave the implementation and the instructions out of sync.

## Impact
This adds a constrained linked-worktree creation tool, covers it with tests, and documents the path validation and workflow expectations. For this repository specifically, agents are now directed to use `git_worktree_add` during setup, while other repositories can still choose `git_branch_create_and_switch` when linked worktree creation would be too expensive.