### PR TITLE
config: add branching_policy workflow hints

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ defaults:
   allowed_branch_patterns:
     - "^main$"
   allow_draft_prs: true
+  branching_policy: worktree
 
 always_allowed_branch_patterns:
   - "^user/.*$"
@@ -59,6 +60,7 @@ repositories:
   - path: ~/projects/codex-git-unleash-mcp
     default_remote: origin
   - path: ~/projects/another-repo
+    branching_policy: current_branch
     allowed_branch_patterns:
       - "^feature/[a-z0-9._-]+$"
     allow_draft_prs: false
@@ -67,13 +69,17 @@ repositories:
 Notes:
 
 - `path` must be an absolute path or start with `~/`
-- top-level `defaults` are optional and may define `allowed_branch_patterns`, `default_remote`, and `allow_draft_prs`
+- top-level `defaults` are optional and may define `allowed_branch_patterns`, `default_remote`, `allow_draft_prs`, and `branching_policy`
 - top-level `always_allowed_branch_patterns` are optional and are appended to every repository's effective branch policy
 - repository values override top-level defaults field-by-field
 - `defaults.allowed_branch_patterns` are inherited or overridden, while `always_allowed_branch_patterns` are always added
+- `branching_policy` is optional and advisory; supported values are `worktree`, `branch`, and `current_branch`
+- `worktree` means the preferred setup flow is `git_worktree_add`
+- `branch` means the preferred setup flow is `git_branch_create_and_switch`
+- `current_branch` means do not create a new worktree or feature branch; work directly on the current allowed branch
 - branch patterns are full-match regexes against the current branch name
 - each repository must end up with at least one effective allowed branch pattern, either from the repo entry, inherited `defaults`, or `always_allowed_branch_patterns`
-- `git_repo_policy` returns the configured branch patterns and related repository defaults for an allowlisted repository
+- `git_repo_policy` returns the configured branch patterns and related repository defaults for an allowlisted repository, including `branching_policy` when configured
 - `git_add`, `git_commit`, `git_push`, and `gh_pr_create_draft` require the current branch to match one of the configured patterns
 - `git_fetch` only requires the repository to be allowlisted, fetches from the resolved remote, and uses an explicit branch when provided or the detected base branch otherwise
 - `git_worktree_add` requires an explicit absolute target path outside the repository root, validates the requested new branch name against `allowed_branch_patterns`, and creates a linked worktree from an explicit or detected upstream base branch
@@ -208,4 +214,19 @@ repositories:
   - path: ~/projects/codex-git-unleash-mcp-enterprise
     allowed_branch_patterns:
       - "^feature/[a-z0-9._-]+$"
+```
+
+If you want some repositories to stay on their base branch instead of creating a worktree or feature branch:
+
+```yaml
+repositories:
+  - path: ~/projects/dm-cv-on-steroids
+    branching_policy: current_branch
+    allowed_branch_patterns:
+      - "^main$"
+  - path: ~/dot.files
+    branching_policy: current_branch
+    allowed_branch_patterns:
+      - "^main$"
+```
 ```

--- a/SPEC.md
+++ b/SPEC.md
@@ -147,6 +147,7 @@ Optional configuration that may be useful:
 
 - default remote name
 - whether draft PR creation is enabled
+- advisory branching workflow policy (`worktree`, `branch`, or `current_branch`)
 
 The initial branch and PR behavior should prefer runtime inference with a narrow fallback order:
 
@@ -164,6 +165,7 @@ repositories:
       - "^user/.*$"
       - "^feature/[a-z0-9._-]+$"
     allow_draft_prs: true
+    branching_policy: worktree
 ```
 
 ## Describe Support

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,12 +6,15 @@ import { parse as parseYaml } from "yaml";
 import { z } from "zod";
 
 import { ConfigError } from "./errors.js";
-import type { Config, RepoPolicy } from "./types/config.js";
+import type { BranchingPolicy, Config, RepoPolicy } from "./types/config.js";
+
+const branchingPolicySchema = z.enum(["worktree", "branch", "current_branch"]);
 
 const policyDefaultsSchema = z.object({
   allowed_branch_patterns: z.array(z.string().min(1)).nonempty().optional(),
   default_remote: z.string().min(1).optional(),
   allow_draft_prs: z.boolean().optional(),
+  branching_policy: branchingPolicySchema.optional(),
 });
 
 const repoPolicySchema = policyDefaultsSchema.extend({
@@ -63,12 +66,20 @@ export async function loadConfig(configPath: string): Promise<Config> {
       allowedBranchPatterns,
       defaultRemote: repo.default_remote ?? config.defaults?.default_remote,
       allowDraftPrs: repo.allow_draft_prs ?? config.defaults?.allow_draft_prs ?? true,
+      branchingPolicy: resolveBranchingPolicy(repo.branching_policy, config.defaults?.branching_policy),
     });
 
     seenPaths.add(canonicalPath);
   }
 
   return { repositories };
+}
+
+function resolveBranchingPolicy(
+  repoPolicy: BranchingPolicy | undefined,
+  defaultPolicy: BranchingPolicy | undefined,
+): BranchingPolicy | undefined {
+  return repoPolicy ?? defaultPolicy;
 }
 
 function expandHomeDir(inputPath: string): string {

--- a/src/tools/gitRepoPolicy.ts
+++ b/src/tools/gitRepoPolicy.ts
@@ -6,6 +6,7 @@ export type GitRepoPolicyResult = {
   allowedBranchPatterns: string[];
   defaultRemote?: string;
   allowDraftPrs: boolean;
+  branchingPolicy?: string;
 };
 
 export function getGitRepoPolicy(repo: RepoPolicy): GitRepoPolicyResult {
@@ -15,5 +16,6 @@ export function getGitRepoPolicy(repo: RepoPolicy): GitRepoPolicyResult {
     allowedBranchPatterns: repo.allowedBranchPatterns.map((pattern) => pattern.source),
     defaultRemote: repo.defaultRemote,
     allowDraftPrs: repo.allowDraftPrs,
+    branchingPolicy: repo.branchingPolicy,
   };
 }

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -1,3 +1,5 @@
+export type BranchingPolicy = "worktree" | "branch" | "current_branch";
+
 export type RepoPolicy = {
   path: string;
   canonicalPath: string;
@@ -5,6 +7,7 @@ export type RepoPolicy = {
   allowedBranchPatterns: RegExp[];
   defaultRemote?: string;
   allowDraftPrs: boolean;
+  branchingPolicy?: BranchingPolicy;
 };
 
 export type Config = {

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -31,6 +31,7 @@ describe("loadConfig", () => {
     expect(config.repositories[0]?.canonicalPath).toBe(canonicalRepoDir);
     expect(config.repositories[0]?.defaultRemote).toBeUndefined();
     expect(config.repositories[0]?.allowDraftPrs).toBe(true);
+    expect(config.repositories[0]?.branchingPolicy).toBeUndefined();
     expect(config.repositories[0]?.allowedBranchPatterns.map((pattern) => pattern.source)).toEqual(["^feature\\/.+$"]);
   });
 
@@ -47,6 +48,7 @@ describe("loadConfig", () => {
         '    - "^user/.+$"',
         "  default_remote: upstream",
         "  allow_draft_prs: false",
+        "  branching_policy: worktree",
         "repositories:",
         `  - path: ${repoDir}`,
       ].join("\n"),
@@ -58,6 +60,7 @@ describe("loadConfig", () => {
     expect(config.repositories[0]?.allowedBranchPatterns.map((pattern) => pattern.source)).toEqual(["^user\\/.+$"]);
     expect(config.repositories[0]?.defaultRemote).toBe("upstream");
     expect(config.repositories[0]?.allowDraftPrs).toBe(false);
+    expect(config.repositories[0]?.branchingPolicy).toBe("worktree");
   });
 
   it("appends always-allowed branch patterns to repository policy", async () => {
@@ -99,12 +102,14 @@ describe("loadConfig", () => {
         '    - "^user/.+$"',
         "  default_remote: upstream",
         "  allow_draft_prs: false",
+        "  branching_policy: worktree",
         "repositories:",
         `  - path: ${repoDir}`,
         "    allowed_branch_patterns:",
         '      - "^feature/.+$"',
         "    default_remote: origin",
         "    allow_draft_prs: true",
+        "    branching_policy: current_branch",
       ].join("\n"),
       "utf8",
     );
@@ -114,6 +119,7 @@ describe("loadConfig", () => {
     expect(config.repositories[0]?.allowedBranchPatterns.map((pattern) => pattern.source)).toEqual(["^feature\\/.+$"]);
     expect(config.repositories[0]?.defaultRemote).toBe("origin");
     expect(config.repositories[0]?.allowDraftPrs).toBe(true);
+    expect(config.repositories[0]?.branchingPolicy).toBe("current_branch");
   });
 
   it("appends always-allowed branch patterns to inherited defaults", async () => {
@@ -195,5 +201,27 @@ describe("loadConfig", () => {
     } finally {
       homedirSpy.mockRestore();
     }
+  });
+
+  it("accepts repository-level current-branch workflow policy without defaults", async () => {
+    const repoDir = await fs.mkdtemp(path.join(os.tmpdir(), "git-mcp-current-branch-repo-"));
+    const configPath = path.join(os.tmpdir(), `git-mcp-config-${Date.now()}-current-branch.yaml`);
+    tempPaths.push(repoDir, configPath);
+
+    await fs.writeFile(
+      configPath,
+      [
+        "repositories:",
+        `  - path: ${repoDir}`,
+        "    branching_policy: current_branch",
+        "    allowed_branch_patterns:",
+        '      - "^main$"',
+      ].join("\n"),
+      "utf8",
+    );
+
+    const config = await loadConfig(configPath);
+
+    expect(config.repositories[0]?.branchingPolicy).toBe("current_branch");
   });
 });

--- a/tests/gitRepoPolicy.test.ts
+++ b/tests/gitRepoPolicy.test.ts
@@ -12,6 +12,7 @@ describe("getGitRepoPolicy", () => {
       allowedBranchPatterns: [/^user\/.*$/, /^feature\/[a-z0-9._-]+$/],
       defaultRemote: "origin",
       allowDraftPrs: true,
+      branchingPolicy: "current_branch",
     };
 
     expect(getGitRepoPolicy(repo)).toEqual({
@@ -20,6 +21,7 @@ describe("getGitRepoPolicy", () => {
       allowedBranchPatterns: ["^user\\/.*$", "^feature\\/[a-z0-9._-]+$"],
       defaultRemote: "origin",
       allowDraftPrs: true,
+      branchingPolicy: "current_branch",
     });
   });
 });


### PR DESCRIPTION
## Why
Some repositories should prefer different setup flows before mutation: a linked worktree, a branch in the current worktree, or staying on the current allowed branch. The config only exposed branch authorization and remote defaults, so clients had no structured way to distinguish those workflows.

This adds an optional `branching_policy` field to repository config and exposes it via `git_repo_policy`, so clients can make a deterministic workflow choice without hard-coding repo-specific behavior. It also documents the `current_branch` case for repositories that should always commit on their base branch.

## Impact
Clients can now read `worktree`, `branch`, or `current_branch` from policy and choose the corresponding workflow while keeping branch authorization unchanged. Existing configs remain valid because the field is optional.

The main risk is interpretation drift if a client treats `branching_policy` as an enforcement mechanism rather than advisory workflow guidance. The docs and spec now call out that distinction explicitly.