### PR TITLE
git-mcp: enforce branching_policy in setup tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Notes:
 - top-level `always_allowed_branch_patterns` are optional and are appended to every repository's effective branch policy
 - repository values override top-level defaults field-by-field
 - `defaults.allowed_branch_patterns` are inherited or overridden, while `always_allowed_branch_patterns` are always added
-- `branching_policy` is optional and advisory; supported values are `worktree`, `branch`, and `current_branch`
+- `branching_policy` is optional and enforced for branch-setup tools; supported values are `worktree`, `branch`, and `current_branch`
 - `worktree` means the preferred setup flow is `git_worktree_add`
 - `branch` means the preferred setup flow is `git_branch_create_and_switch`
 - `current_branch` means do not create a new worktree or feature branch; work directly on the current allowed branch
@@ -82,9 +82,9 @@ Notes:
 - `git_repo_policy` returns the configured branch patterns and related repository defaults for an allowlisted repository, including `branching_policy` when configured
 - `git_add`, `git_commit`, `git_push`, and `gh_pr_create_draft` require the current branch to match one of the configured patterns
 - `git_fetch` only requires the repository to be allowlisted, fetches from the resolved remote, and uses an explicit branch when provided or the detected base branch otherwise
-- `git_worktree_add` requires an explicit absolute target path outside the repository root, validates the requested new branch name against `allowed_branch_patterns`, and creates a linked worktree from an explicit or detected upstream base branch
+- `git_worktree_add` requires an explicit absolute target path outside the repository root, validates the requested new branch name against `allowed_branch_patterns`, creates a linked worktree from an explicit or detected upstream base branch, and is only allowed when `branching_policy` is unset or `worktree`
 - `git_branch_create_and_switch` and `git_branch_switch` require a clean worktree
-- `git_branch_create_and_switch` also requires the requested new branch name to match `allowed_branch_patterns`
+- `git_branch_create_and_switch` also requires the requested new branch name to match `allowed_branch_patterns`, and is only allowed when `branching_policy` is unset or `branch`
 - remote resolution prefers configured `default_remote` when present and valid, then the current branch's remote, then `origin`
 - branch creation and PR base resolution prefer the remote HEAD branch and fall back to GitHub default-branch detection when needed
 - `git_status` only requires the repository to be allowlisted

--- a/SPEC.md
+++ b/SPEC.md
@@ -147,7 +147,7 @@ Optional configuration that may be useful:
 
 - default remote name
 - whether draft PR creation is enabled
-- advisory branching workflow policy (`worktree`, `branch`, or `current_branch`)
+- branching workflow policy (`worktree`, `branch`, or `current_branch`) enforced for branch-setup tools
 
 The initial branch and PR behavior should prefer runtime inference with a narrow fallback order:
 

--- a/src/auth/branchingPolicy.ts
+++ b/src/auth/branchingPolicy.ts
@@ -1,0 +1,16 @@
+import { BranchingPolicyViolationError } from "../errors.js";
+import type { BranchingPolicy, RepoPolicy } from "../types/config.js";
+
+export function requireBranchingPolicy(
+  repo: RepoPolicy,
+  toolName: string,
+  allowedPolicies: BranchingPolicy[],
+): void {
+  if (!repo.branchingPolicy) {
+    return;
+  }
+
+  if (!allowedPolicies.includes(repo.branchingPolicy)) {
+    throw new BranchingPolicyViolationError(toolName, repo.worktreePath, repo.branchingPolicy);
+  }
+}

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -30,6 +30,15 @@ export class BranchNameNotAllowedError extends Error {
   }
 }
 
+export class BranchingPolicyViolationError extends Error {
+  constructor(toolName: string, repoPath: string, actualPolicy: string) {
+    super(
+      `tool '${toolName}' is not allowed for repository '${repoPath}' under branching_policy '${actualPolicy}'; call 'git_repo_policy' and use the setup flow required by that policy`,
+    );
+    this.name = "BranchingPolicyViolationError";
+  }
+}
+
 export class DetachedHeadError extends Error {
   constructor(repoPath: string) {
     super(`repository '${repoPath}' is in detached HEAD state`);

--- a/src/tools/gitBranchCreateAndSwitch.ts
+++ b/src/tools/gitBranchCreateAndSwitch.ts
@@ -1,4 +1,5 @@
 import { requireAllowedBranchName } from "../auth/branchAuth.js";
+import { requireBranchingPolicy } from "../auth/branchingPolicy.js";
 import { BranchAlreadyExistsError, DirtyWorktreeError, EmptyBranchNameError } from "../errors.js";
 import { branchExists, createBranch, fetchBranch, switchBranch } from "../exec/git.js";
 import type { RepoPolicy } from "../types/config.js";
@@ -15,6 +16,7 @@ export async function gitBranchCreateAndSwitch(
   repo: RepoPolicy,
   input: { newBranch: string; branch?: string },
 ): Promise<GitBranchCreateAndSwitchResult> {
+  requireBranchingPolicy(repo, "git_branch_create_and_switch", ["branch"]);
   const normalizedBranch = input.newBranch.trim();
   if (!normalizedBranch) {
     throw new EmptyBranchNameError();

--- a/src/tools/gitWorktreeAdd.ts
+++ b/src/tools/gitWorktreeAdd.ts
@@ -1,4 +1,5 @@
 import { requireAllowedBranchName } from "../auth/branchAuth.js";
+import { requireBranchingPolicy } from "../auth/branchingPolicy.js";
 import { validateWorktreePath } from "../auth/pathValidation.js";
 import { BranchAlreadyExistsError, EmptyBranchNameError } from "../errors.js";
 import { addWorktree, branchExists, fetchBranch } from "../exec/git.js";
@@ -16,6 +17,7 @@ export async function gitWorktreeAdd(
   repo: RepoPolicy,
   input: { path: string; newBranch: string; branch?: string },
 ): Promise<GitWorktreeAddResult> {
+  requireBranchingPolicy(repo, "git_worktree_add", ["worktree"]);
   const normalizedBranch = input.newBranch.trim();
   if (!normalizedBranch) {
     throw new EmptyBranchNameError();

--- a/tests/gitBranchCreateAndSwitch.test.ts
+++ b/tests/gitBranchCreateAndSwitch.test.ts
@@ -7,6 +7,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import {
   BranchAlreadyExistsError,
   BranchNameNotAllowedError,
+  BranchingPolicyViolationError,
   DirtyWorktreeError,
   EmptyBranchNameError,
 } from "../src/errors.js";
@@ -130,6 +131,36 @@ describe("gitBranchCreateAndSwitch", () => {
         { newBranch: "codex/disallowed" },
       ),
     ).rejects.toBeInstanceOf(BranchNameNotAllowedError);
+  });
+
+  it("rejects branch creation when branching_policy requires worktree mode", async () => {
+    const { repoDir, repo } = await createTempGitRepo();
+    tempPaths.push(repoDir);
+
+    await expect(
+      gitBranchCreateAndSwitch(
+        {
+          ...repo,
+          branchingPolicy: "worktree",
+        },
+        { newBranch: "feature/from-branch-tool" },
+      ),
+    ).rejects.toBeInstanceOf(BranchingPolicyViolationError);
+  });
+
+  it("rejects branch creation when branching_policy requires current_branch", async () => {
+    const { repoDir, repo } = await createTempGitRepo();
+    tempPaths.push(repoDir);
+
+    await expect(
+      gitBranchCreateAndSwitch(
+        {
+          ...repo,
+          branchingPolicy: "current_branch",
+        },
+        { newBranch: "feature/from-current-branch" },
+      ),
+    ).rejects.toBeInstanceOf(BranchingPolicyViolationError);
   });
 
   it("uses an explicit upstream branch when provided", async () => {

--- a/tests/gitWorktreeAdd.test.ts
+++ b/tests/gitWorktreeAdd.test.ts
@@ -4,7 +4,12 @@ import path from "node:path";
 
 import { afterEach, describe, expect, it } from "vitest";
 
-import { BranchAlreadyExistsError, BranchNameNotAllowedError, PathValidationError } from "../src/errors.js";
+import {
+  BranchAlreadyExistsError,
+  BranchNameNotAllowedError,
+  BranchingPolicyViolationError,
+  PathValidationError,
+} from "../src/errors.js";
 import { getCurrentBranch } from "../src/exec/git.js";
 import { runCommand } from "../src/exec/run.js";
 import { gitAdd } from "../src/tools/gitAdd.js";
@@ -117,6 +122,42 @@ describe("gitWorktreeAdd", () => {
         },
       ),
     ).rejects.toBeInstanceOf(BranchNameNotAllowedError);
+  });
+
+  it("rejects worktree creation when branching_policy requires branch mode", async () => {
+    const { repoDir, repo } = await createTempGitRepo();
+    tempPaths.push(repoDir);
+
+    await expect(
+      gitWorktreeAdd(
+        {
+          ...repo,
+          branchingPolicy: "branch",
+        },
+        {
+          path: "/tmp/git-mcp-policy-mismatch-worktree",
+          newBranch: "feature/from-worktree",
+        },
+      ),
+    ).rejects.toBeInstanceOf(BranchingPolicyViolationError);
+  });
+
+  it("rejects worktree creation when branching_policy requires current_branch", async () => {
+    const { repoDir, repo } = await createTempGitRepo();
+    tempPaths.push(repoDir);
+
+    await expect(
+      gitWorktreeAdd(
+        {
+          ...repo,
+          branchingPolicy: "current_branch",
+        },
+        {
+          path: "/tmp/git-mcp-current-branch-worktree",
+          newBranch: "feature/from-current-branch",
+        },
+      ),
+    ).rejects.toBeInstanceOf(BranchingPolicyViolationError);
   });
 
   it("rejects duplicate local branch names", async () => {


### PR DESCRIPTION
## Why
`branching_policy` was exposed through `git_repo_policy`, but the MCP still treated it as advisory. That meant an agent could ignore the repository's intended setup flow and still call `git_worktree_add` or `git_branch_create_and_switch` successfully as long as the branch name matched policy.

This change moves that decision into the MCP enforcement boundary. Repositories configured for `worktree`, `branch`, or `current_branch` now get a server-side rejection when an agent calls the wrong setup tool, instead of relying on instructions alone.

## Impact
Positive:
- branch setup now follows repository policy at the tool layer rather than prompt compliance
- agents get a specific error directing them back to `git_repo_policy`
- regression tests cover the new mismatch cases

Potential downside:
- repositories that were previously setting `branching_policy` for documentation only will now see enforcement failures until agents or configs are updated
- `git_branch_switch` is unchanged in this PR, so this only tightens the new-branch and new-worktree setup paths

## Verification
- `npm run typecheck`
- `npm test -- tests/gitWorktreeAdd.test.ts tests/gitBranchCreateAndSwitch.test.ts`