### PR TITLE
git-mcp: rename feature-branch strategy and allow multiple setup policies

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,8 @@ defaults:
   allowed_branch_patterns:
     - "^main$"
   allow_draft_prs: true
-  branching_policy: worktree
+  branching_policies:
+    - worktree
 
 always_allowed_branch_patterns:
   - "^user/.*$"
@@ -60,7 +61,9 @@ repositories:
   - path: ~/projects/codex-git-unleash-mcp
     default_remote: origin
   - path: ~/projects/another-repo
-    branching_policy: current_branch
+    branching_policies:
+      - current_branch
+      - feature_branch
     allowed_branch_patterns:
       - "^feature/[a-z0-9._-]+$"
     allow_draft_prs: false
@@ -69,22 +72,23 @@ repositories:
 Notes:
 
 - `path` must be an absolute path or start with `~/`
-- top-level `defaults` are optional and may define `allowed_branch_patterns`, `default_remote`, `allow_draft_prs`, and `branching_policy`
+- top-level `defaults` are optional and may define `allowed_branch_patterns`, `default_remote`, `allow_draft_prs`, and `branching_policies`
 - top-level `always_allowed_branch_patterns` are optional and are appended to every repository's effective branch policy
 - repository values override top-level defaults field-by-field
 - `defaults.allowed_branch_patterns` are inherited or overridden, while `always_allowed_branch_patterns` are always added
-- `branching_policy` is optional and enforced for branch-setup tools; supported values are `worktree`, `branch`, and `current_branch`
+- `branching_policies` is optional and enforced for branch-setup tools; supported values are `worktree`, `feature_branch`, and `current_branch`
 - `worktree` means the preferred setup flow is `git_worktree_add`
-- `branch` means the preferred setup flow is `git_branch_create_and_switch`
+- `feature_branch` means the preferred setup flow is `git_branch_create_and_switch`
 - `current_branch` means do not create a new worktree or feature branch; work directly on the current allowed branch
+- when `branching_policies` contains multiple values, any matching setup flow is allowed
 - branch patterns are full-match regexes against the current branch name
 - each repository must end up with at least one effective allowed branch pattern, either from the repo entry, inherited `defaults`, or `always_allowed_branch_patterns`
-- `git_repo_policy` returns the configured branch patterns and related repository defaults for an allowlisted repository, including `branching_policy` when configured
+- `git_repo_policy` returns the configured branch patterns and related repository defaults for an allowlisted repository, including `branching_policies` when configured
 - `git_add`, `git_commit`, `git_push`, and `gh_pr_create_draft` require the current branch to match one of the configured patterns
 - `git_fetch` only requires the repository to be allowlisted, fetches from the resolved remote, and uses an explicit branch when provided or the detected base branch otherwise
-- `git_worktree_add` requires an explicit absolute target path outside the repository root, validates the requested new branch name against `allowed_branch_patterns`, creates a linked worktree from an explicit or detected upstream base branch, and is only allowed when `branching_policy` is unset or `worktree`
+- `git_worktree_add` requires an explicit absolute target path outside the repository root, validates the requested new branch name against `allowed_branch_patterns`, creates a linked worktree from an explicit or detected upstream base branch, and is only allowed when `branching_policies` is unset or includes `worktree`
 - `git_branch_create_and_switch` and `git_branch_switch` require a clean worktree
-- `git_branch_create_and_switch` also requires the requested new branch name to match `allowed_branch_patterns`, and is only allowed when `branching_policy` is unset or `branch`
+- `git_branch_create_and_switch` also requires the requested new branch name to match `allowed_branch_patterns`, and is only allowed when `branching_policies` is unset or includes `feature_branch`
 - remote resolution prefers configured `default_remote` when present and valid, then the current branch's remote, then `origin`
 - branch creation and PR base resolution prefer the remote HEAD branch and fall back to GitHub default-branch detection when needed
 - `git_status` only requires the repository to be allowlisted
@@ -221,11 +225,13 @@ If you want some repositories to stay on their base branch instead of creating a
 ```yaml
 repositories:
   - path: ~/projects/dm-cv-on-steroids
-    branching_policy: current_branch
+    branching_policies:
+      - current_branch
     allowed_branch_patterns:
       - "^main$"
   - path: ~/dot.files
-    branching_policy: current_branch
+    branching_policies:
+      - current_branch
     allowed_branch_patterns:
       - "^main$"
 ```

--- a/SPEC.md
+++ b/SPEC.md
@@ -147,7 +147,7 @@ Optional configuration that may be useful:
 
 - default remote name
 - whether draft PR creation is enabled
-- branching workflow policy (`worktree`, `branch`, or `current_branch`) enforced for branch-setup tools
+- branching workflow policies (`worktree`, `feature_branch`, or `current_branch`) enforced for branch-setup tools
 
 The initial branch and PR behavior should prefer runtime inference with a narrow fallback order:
 
@@ -165,7 +165,8 @@ repositories:
       - "^user/.*$"
       - "^feature/[a-z0-9._-]+$"
     allow_draft_prs: true
-    branching_policy: worktree
+    branching_policies:
+      - worktree
 ```
 
 ## Describe Support

--- a/src/auth/branchingPolicy.ts
+++ b/src/auth/branchingPolicy.ts
@@ -6,11 +6,11 @@ export function requireBranchingPolicy(
   toolName: string,
   allowedPolicies: BranchingPolicy[],
 ): void {
-  if (!repo.branchingPolicy) {
+  if (!repo.branchingPolicies || repo.branchingPolicies.length === 0) {
     return;
   }
 
-  if (!allowedPolicies.includes(repo.branchingPolicy)) {
-    throw new BranchingPolicyViolationError(toolName, repo.worktreePath, repo.branchingPolicy);
+  if (!repo.branchingPolicies.some((policy) => allowedPolicies.includes(policy))) {
+    throw new BranchingPolicyViolationError(toolName, repo.worktreePath, repo.branchingPolicies);
   }
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -8,13 +8,14 @@ import { z } from "zod";
 import { ConfigError } from "./errors.js";
 import type { BranchingPolicy, Config, RepoPolicy } from "./types/config.js";
 
-const branchingPolicySchema = z.enum(["worktree", "branch", "current_branch"]);
+const branchingPolicySchema = z.enum(["worktree", "feature_branch", "current_branch"]);
+const branchingPoliciesSchema = z.array(branchingPolicySchema).nonempty();
 
 const policyDefaultsSchema = z.object({
   allowed_branch_patterns: z.array(z.string().min(1)).nonempty().optional(),
   default_remote: z.string().min(1).optional(),
   allow_draft_prs: z.boolean().optional(),
-  branching_policy: branchingPolicySchema.optional(),
+  branching_policies: branchingPoliciesSchema.optional(),
 });
 
 const repoPolicySchema = policyDefaultsSchema.extend({
@@ -66,7 +67,7 @@ export async function loadConfig(configPath: string): Promise<Config> {
       allowedBranchPatterns,
       defaultRemote: repo.default_remote ?? config.defaults?.default_remote,
       allowDraftPrs: repo.allow_draft_prs ?? config.defaults?.allow_draft_prs ?? true,
-      branchingPolicy: resolveBranchingPolicy(repo.branching_policy, config.defaults?.branching_policy),
+      branchingPolicies: resolveBranchingPolicies(repo.branching_policies, config.defaults?.branching_policies),
     });
 
     seenPaths.add(canonicalPath);
@@ -75,11 +76,11 @@ export async function loadConfig(configPath: string): Promise<Config> {
   return { repositories };
 }
 
-function resolveBranchingPolicy(
-  repoPolicy: BranchingPolicy | undefined,
-  defaultPolicy: BranchingPolicy | undefined,
-): BranchingPolicy | undefined {
-  return repoPolicy ?? defaultPolicy;
+function resolveBranchingPolicies(
+  repoPolicies: BranchingPolicy[] | undefined,
+  defaultPolicies: BranchingPolicy[] | undefined,
+): BranchingPolicy[] | undefined {
+  return repoPolicies ?? defaultPolicies;
 }
 
 function expandHomeDir(inputPath: string): string {

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -31,9 +31,9 @@ export class BranchNameNotAllowedError extends Error {
 }
 
 export class BranchingPolicyViolationError extends Error {
-  constructor(toolName: string, repoPath: string, actualPolicy: string) {
+  constructor(toolName: string, repoPath: string, actualPolicies: string[]) {
     super(
-      `tool '${toolName}' is not allowed for repository '${repoPath}' under branching_policy '${actualPolicy}'; call 'git_repo_policy' and use the setup flow required by that policy`,
+      `tool '${toolName}' is not allowed for repository '${repoPath}' under branching_policies [${actualPolicies.join(", ")}]; call 'git_repo_policy' and use one of the configured setup flows`,
     );
     this.name = "BranchingPolicyViolationError";
   }

--- a/src/tools/gitBranchCreateAndSwitch.ts
+++ b/src/tools/gitBranchCreateAndSwitch.ts
@@ -16,7 +16,7 @@ export async function gitBranchCreateAndSwitch(
   repo: RepoPolicy,
   input: { newBranch: string; branch?: string },
 ): Promise<GitBranchCreateAndSwitchResult> {
-  requireBranchingPolicy(repo, "git_branch_create_and_switch", ["branch"]);
+  requireBranchingPolicy(repo, "git_branch_create_and_switch", ["feature_branch"]);
   const normalizedBranch = input.newBranch.trim();
   if (!normalizedBranch) {
     throw new EmptyBranchNameError();

--- a/src/tools/gitRepoPolicy.ts
+++ b/src/tools/gitRepoPolicy.ts
@@ -6,7 +6,7 @@ export type GitRepoPolicyResult = {
   allowedBranchPatterns: string[];
   defaultRemote?: string;
   allowDraftPrs: boolean;
-  branchingPolicy?: string;
+  branchingPolicies?: string[];
 };
 
 export function getGitRepoPolicy(repo: RepoPolicy): GitRepoPolicyResult {
@@ -16,6 +16,6 @@ export function getGitRepoPolicy(repo: RepoPolicy): GitRepoPolicyResult {
     allowedBranchPatterns: repo.allowedBranchPatterns.map((pattern) => pattern.source),
     defaultRemote: repo.defaultRemote,
     allowDraftPrs: repo.allowDraftPrs,
-    branchingPolicy: repo.branchingPolicy,
+    branchingPolicies: repo.branchingPolicies,
   };
 }

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -1,4 +1,4 @@
-export type BranchingPolicy = "worktree" | "branch" | "current_branch";
+export type BranchingPolicy = "worktree" | "feature_branch" | "current_branch";
 
 export type RepoPolicy = {
   path: string;
@@ -7,7 +7,7 @@ export type RepoPolicy = {
   allowedBranchPatterns: RegExp[];
   defaultRemote?: string;
   allowDraftPrs: boolean;
-  branchingPolicy?: BranchingPolicy;
+  branchingPolicies?: BranchingPolicy[];
 };
 
 export type Config = {

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -31,7 +31,7 @@ describe("loadConfig", () => {
     expect(config.repositories[0]?.canonicalPath).toBe(canonicalRepoDir);
     expect(config.repositories[0]?.defaultRemote).toBeUndefined();
     expect(config.repositories[0]?.allowDraftPrs).toBe(true);
-    expect(config.repositories[0]?.branchingPolicy).toBeUndefined();
+    expect(config.repositories[0]?.branchingPolicies).toBeUndefined();
     expect(config.repositories[0]?.allowedBranchPatterns.map((pattern) => pattern.source)).toEqual(["^feature\\/.+$"]);
   });
 
@@ -48,7 +48,8 @@ describe("loadConfig", () => {
         '    - "^user/.+$"',
         "  default_remote: upstream",
         "  allow_draft_prs: false",
-        "  branching_policy: worktree",
+        "  branching_policies:",
+        "    - worktree",
         "repositories:",
         `  - path: ${repoDir}`,
       ].join("\n"),
@@ -60,7 +61,7 @@ describe("loadConfig", () => {
     expect(config.repositories[0]?.allowedBranchPatterns.map((pattern) => pattern.source)).toEqual(["^user\\/.+$"]);
     expect(config.repositories[0]?.defaultRemote).toBe("upstream");
     expect(config.repositories[0]?.allowDraftPrs).toBe(false);
-    expect(config.repositories[0]?.branchingPolicy).toBe("worktree");
+    expect(config.repositories[0]?.branchingPolicies).toEqual(["worktree"]);
   });
 
   it("appends always-allowed branch patterns to repository policy", async () => {
@@ -102,14 +103,17 @@ describe("loadConfig", () => {
         '    - "^user/.+$"',
         "  default_remote: upstream",
         "  allow_draft_prs: false",
-        "  branching_policy: worktree",
+        "  branching_policies:",
+        "    - worktree",
         "repositories:",
         `  - path: ${repoDir}`,
         "    allowed_branch_patterns:",
         '      - "^feature/.+$"',
         "    default_remote: origin",
         "    allow_draft_prs: true",
-        "    branching_policy: current_branch",
+        "    branching_policies:",
+        "      - current_branch",
+        "      - feature_branch",
       ].join("\n"),
       "utf8",
     );
@@ -119,7 +123,7 @@ describe("loadConfig", () => {
     expect(config.repositories[0]?.allowedBranchPatterns.map((pattern) => pattern.source)).toEqual(["^feature\\/.+$"]);
     expect(config.repositories[0]?.defaultRemote).toBe("origin");
     expect(config.repositories[0]?.allowDraftPrs).toBe(true);
-    expect(config.repositories[0]?.branchingPolicy).toBe("current_branch");
+    expect(config.repositories[0]?.branchingPolicies).toEqual(["current_branch", "feature_branch"]);
   });
 
   it("appends always-allowed branch patterns to inherited defaults", async () => {
@@ -213,7 +217,8 @@ describe("loadConfig", () => {
       [
         "repositories:",
         `  - path: ${repoDir}`,
-        "    branching_policy: current_branch",
+        "    branching_policies:",
+        "      - current_branch",
         "    allowed_branch_patterns:",
         '      - "^main$"',
       ].join("\n"),
@@ -222,6 +227,6 @@ describe("loadConfig", () => {
 
     const config = await loadConfig(configPath);
 
-    expect(config.repositories[0]?.branchingPolicy).toBe("current_branch");
+    expect(config.repositories[0]?.branchingPolicies).toEqual(["current_branch"]);
   });
 });

--- a/tests/gitBranchCreateAndSwitch.test.ts
+++ b/tests/gitBranchCreateAndSwitch.test.ts
@@ -133,7 +133,7 @@ describe("gitBranchCreateAndSwitch", () => {
     ).rejects.toBeInstanceOf(BranchNameNotAllowedError);
   });
 
-  it("rejects branch creation when branching_policy requires worktree mode", async () => {
+  it("rejects branch creation when branching_policies excludes feature_branch", async () => {
     const { repoDir, repo } = await createTempGitRepo();
     tempPaths.push(repoDir);
 
@@ -141,14 +141,14 @@ describe("gitBranchCreateAndSwitch", () => {
       gitBranchCreateAndSwitch(
         {
           ...repo,
-          branchingPolicy: "worktree",
+          branchingPolicies: ["worktree"],
         },
         { newBranch: "feature/from-branch-tool" },
       ),
     ).rejects.toBeInstanceOf(BranchingPolicyViolationError);
   });
 
-  it("rejects branch creation when branching_policy requires current_branch", async () => {
+  it("rejects branch creation when branching_policies excludes feature_branch via current_branch-only mode", async () => {
     const { repoDir, repo } = await createTempGitRepo();
     tempPaths.push(repoDir);
 
@@ -156,11 +156,42 @@ describe("gitBranchCreateAndSwitch", () => {
       gitBranchCreateAndSwitch(
         {
           ...repo,
-          branchingPolicy: "current_branch",
+          branchingPolicies: ["current_branch"],
         },
         { newBranch: "feature/from-current-branch" },
       ),
     ).rejects.toBeInstanceOf(BranchingPolicyViolationError);
+  });
+
+  it("allows branch creation when branching_policies includes feature_branch among multiple strategies", async () => {
+    const { repoDir, repo } = await createTempGitRepo();
+    const remoteDir = await createTempBareGitRepo();
+    tempPaths.push(repoDir, remoteDir);
+
+    await runCommand({ cwd: repoDir, command: "git", argv: ["remote", "add", "origin", remoteDir] });
+    await fs.writeFile(path.join(repoDir, "README.md"), "hello\n", "utf8");
+    await gitAdd(repo, ["README.md"]);
+    await gitCommit(repo, "add readme");
+    await gitPush(repo, "main");
+    await runCommand({
+      cwd: remoteDir,
+      command: "git",
+      argv: ["symbolic-ref", "HEAD", "refs/heads/main"],
+    });
+
+    const result = await gitBranchCreateAndSwitch(
+      {
+        ...repo,
+        branchingPolicies: ["worktree", "feature_branch"],
+      },
+      { newBranch: "feature/multi-strategy" },
+    );
+
+    expect(result).toEqual({
+      branch: "feature/multi-strategy",
+      remote: "origin",
+      base: "main",
+    });
   });
 
   it("uses an explicit upstream branch when provided", async () => {

--- a/tests/gitRepoPolicy.test.ts
+++ b/tests/gitRepoPolicy.test.ts
@@ -12,7 +12,7 @@ describe("getGitRepoPolicy", () => {
       allowedBranchPatterns: [/^user\/.*$/, /^feature\/[a-z0-9._-]+$/],
       defaultRemote: "origin",
       allowDraftPrs: true,
-      branchingPolicy: "current_branch",
+      branchingPolicies: ["current_branch", "feature_branch"],
     };
 
     expect(getGitRepoPolicy(repo)).toEqual({
@@ -21,7 +21,7 @@ describe("getGitRepoPolicy", () => {
       allowedBranchPatterns: ["^user\\/.*$", "^feature\\/[a-z0-9._-]+$"],
       defaultRemote: "origin",
       allowDraftPrs: true,
-      branchingPolicy: "current_branch",
+      branchingPolicies: ["current_branch", "feature_branch"],
     });
   });
 });

--- a/tests/gitWorktreeAdd.test.ts
+++ b/tests/gitWorktreeAdd.test.ts
@@ -124,7 +124,7 @@ describe("gitWorktreeAdd", () => {
     ).rejects.toBeInstanceOf(BranchNameNotAllowedError);
   });
 
-  it("rejects worktree creation when branching_policy requires branch mode", async () => {
+  it("rejects worktree creation when branching_policies excludes worktree", async () => {
     const { repoDir, repo } = await createTempGitRepo();
     tempPaths.push(repoDir);
 
@@ -132,7 +132,7 @@ describe("gitWorktreeAdd", () => {
       gitWorktreeAdd(
         {
           ...repo,
-          branchingPolicy: "branch",
+          branchingPolicies: ["feature_branch"],
         },
         {
           path: "/tmp/git-mcp-policy-mismatch-worktree",
@@ -142,7 +142,7 @@ describe("gitWorktreeAdd", () => {
     ).rejects.toBeInstanceOf(BranchingPolicyViolationError);
   });
 
-  it("rejects worktree creation when branching_policy requires current_branch", async () => {
+  it("rejects worktree creation when branching_policies excludes worktree via current_branch-only mode", async () => {
     const { repoDir, repo } = await createTempGitRepo();
     tempPaths.push(repoDir);
 
@@ -150,7 +150,7 @@ describe("gitWorktreeAdd", () => {
       gitWorktreeAdd(
         {
           ...repo,
-          branchingPolicy: "current_branch",
+          branchingPolicies: ["current_branch"],
         },
         {
           path: "/tmp/git-mcp-current-branch-worktree",
@@ -158,6 +158,44 @@ describe("gitWorktreeAdd", () => {
         },
       ),
     ).rejects.toBeInstanceOf(BranchingPolicyViolationError);
+  });
+
+  it("allows worktree creation when branching_policies includes worktree among multiple strategies", async () => {
+    const { repoDir, repo } = await createTempGitRepo();
+    const remoteDir = await createTempBareGitRepo();
+    const worktreeParentDir = await fs.mkdtemp(path.join(os.tmpdir(), "git-mcp-worktree-add-multi-parent-"));
+    const worktreeDir = path.join(worktreeParentDir, "linked");
+    tempPaths.push(repoDir, remoteDir, worktreeParentDir);
+    const expectedWorktreePath = path.join(await fs.realpath(worktreeParentDir), "linked");
+
+    await runCommand({ cwd: repoDir, command: "git", argv: ["remote", "add", "origin", remoteDir] });
+    await fs.writeFile(path.join(repoDir, "README.md"), "hello\n", "utf8");
+    await gitAdd(repo, ["README.md"]);
+    await gitCommit(repo, "add readme");
+    await gitPush(repo, "main");
+    await runCommand({
+      cwd: remoteDir,
+      command: "git",
+      argv: ["symbolic-ref", "HEAD", "refs/heads/main"],
+    });
+
+    const result = await gitWorktreeAdd(
+      {
+        ...repo,
+        branchingPolicies: ["current_branch", "worktree"],
+      },
+      {
+        path: worktreeDir,
+        newBranch: "feature/multi-strategy-worktree",
+      },
+    );
+
+    expect(result).toEqual({
+      branch: "feature/multi-strategy-worktree",
+      remote: "origin",
+      base: "main",
+      path: expectedWorktreePath,
+    });
   });
 
   it("rejects duplicate local branch names", async () => {


### PR DESCRIPTION
## Why
PR #24 introduced enforcement for branch setup policy, and its review called out two contract issues worth fixing in a follow-up:
- `branch` is ambiguous and should be renamed to `feature_branch`
- the config should not be limited to a single setup strategy when some repositories may want to allow more than one

This PR updates the config and repo-policy surface to make that contract explicit.

## Impact
Positive:
- `branching_policies` can now list multiple allowed setup strategies
- `feature_branch` is clearer than `branch` in config, policy output, and docs
- setup-tool enforcement now accepts any configured matching strategy instead of a single exact mode
- regression tests cover both rejection and multi-strategy acceptance cases

Potential downside:
- this is an intentional breaking config change from `branching_policy` to `branching_policies`
- repositories using the old `branch` value or singular key must update their config

## Verification
- `vitest run tests/config.test.ts tests/gitRepoPolicy.test.ts tests/gitBranchCreateAndSwitch.test.ts tests/gitWorktreeAdd.test.ts`
- `tsc --noEmit -p tsconfig.json`