### PR TITLE
Fix portable config worktree base path test assertion

### DIFF
--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -101,6 +101,10 @@ describe("loadConfig", () => {
     const repoDir = await fs.mkdtemp(path.join(os.tmpdir(), "git-mcp-override-repo-"));
     const configPath = path.join(os.tmpdir(), `git-mcp-config-${Date.now()}-override.yaml`);
     tempPaths.push(repoDir, configPath);
+    const expectedWorktreeBasePath = path.join(
+      await fs.realpath(path.dirname("/tmp/repo-worktrees")),
+      path.basename("/tmp/repo-worktrees"),
+    );
 
     await fs.writeFile(
       configPath,
@@ -133,7 +137,7 @@ describe("loadConfig", () => {
 
      expect(config.repositories[0]?.allowedBranchPatterns.map((pattern) => pattern.source)).toEqual(["^feature\\/.+$"]);
      expect(config.repositories[0]?.featureBranchPattern).toBe("feature/<feature-name>");
-     expect(config.repositories[0]?.gitWorktreeBasePath).toBe("/private/tmp/repo-worktrees");
+     expect(config.repositories[0]?.gitWorktreeBasePath).toBe(expectedWorktreeBasePath);
      expect(config.repositories[0]?.defaultRemote).toBe("origin");
     expect(config.repositories[0]?.allowDraftPrs).toBe(true);
     expect(config.repositories[0]?.branchingPolicies).toEqual(["current_branch", "feature_branch"]);


### PR DESCRIPTION
## Why
The GitHub Actions test job failed after PR 29 because `tests/config.test.ts` hard-coded the macOS-specific canonical form of `/tmp` as `/private/tmp`.

That expectation is not portable. On Ubuntu runners, the same path remains `/tmp`, so the assertion failed even though the config loader behavior was correct.

## Impact
The test now derives the expected canonical worktree base path from the real parent directory at runtime instead of assuming a macOS-only filesystem layout.

This changes test behavior only. Production code is unchanged.

Local verification:
- `npm test`
- `npm run typecheck`