### PR TITLE
[feature] add config bootstrap and repo upsert tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ For the suggested repository workflow used in this repo (and in general), see [A
 
 Current tool surface:
 
+- `config_bootstrap`
+- `config_upsert_repo`
 - `git_repo_policy`
 - `git_status`
 - `git_add`
@@ -44,6 +46,8 @@ npm install
 
 Use a config file at `~/.config/codex-git-unleash-mcp.yaml`.
 
+If that file does not exist yet, the server can still start in a limited config-only mode. In that mode it exposes `config_bootstrap` and `config_upsert_repo` so you can create the initial YAML and add repository entries before enabling the full Git and GitHub tool surface.
+
 Example:
 
 ```yaml
@@ -75,6 +79,9 @@ repositories:
 Notes:
 
 - `path` must be an absolute path or start with `~/`
+- `config_bootstrap` creates a minimal valid YAML config file and refuses to overwrite an existing file
+- `config_upsert_repo` adds or updates one repository entry in the YAML config and matches existing entries by canonical repository path
+- config changes do not hot-reload the running server in this version; restart the MCP server after calling `config_bootstrap` or `config_upsert_repo`
 - top-level `defaults` are optional and may define `allowed_branch_patterns`, `feature_branch_pattern`, `git_worktree_base_path`, `default_remote`, `allow_draft_prs`, and `branching_policies`
 - top-level `always_allowed_branch_patterns` are optional and are appended to every repository's effective branch policy
 - repository values override top-level defaults field-by-field
@@ -104,14 +111,16 @@ Notes:
 
 The intended happy path is:
 
-1. Call `git_repo_policy` or `git_status` to inspect the allowlisted repository.
-2. Before creating a branch, use `git_repo_policy` to confirm the configured `allowed_branch_patterns`, then choose a new branch name that matches that policy.
-3. Call `git_branch_create_and_switch` to branch from an explicit or detected upstream base when you need a new local branch in the current worktree.
-4. Call `git_worktree_add` when you need a separate linked worktree on a new allowed branch at an explicit absolute path.
-5. Call `git_add` with explicit repository-relative paths.
-6. Call `git_commit` with a normal commit message.
-7. Call `git_push` to push the current branch to the resolved remote.
-8. Call `gh_pr_create_draft` to open a draft PR against an explicit base or the detected default base branch.
+1. If the config file does not exist yet, call `config_bootstrap` to create it, then restart the MCP server.
+2. Call `config_upsert_repo` to add or update an allowlisted repository entry when needed, then restart the MCP server.
+3. Call `git_repo_policy` or `git_status` to inspect the allowlisted repository.
+4. Before creating a branch, use `git_repo_policy` to confirm the configured `allowed_branch_patterns`, then choose a new branch name that matches that policy.
+5. Call `git_branch_create_and_switch` to branch from an explicit or detected upstream base when you need a new local branch in the current worktree.
+6. Call `git_worktree_add` when you need a separate linked worktree on a new allowed branch at an explicit absolute path.
+7. Call `git_add` with explicit repository-relative paths.
+8. Call `git_commit` with a normal commit message.
+9. Call `git_push` to push the current branch to the resolved remote.
+10. Call `gh_pr_create_draft` to open a draft PR against an explicit base or the detected default base branch.
 
 Each step stays inside a fixed policy boundary. There is no arbitrary checkout, no arbitrary push refspec, no amend flow, and no non-draft PR creation.
 
@@ -128,6 +137,8 @@ You can also provide the config path through `GIT_UNLEASH_MCP_CONFIG`:
 ```bash
 GIT_UNLEASH_MCP_CONFIG=~/.config/codex-git-unleash-mcp.yaml npm run dev
 ```
+
+If the config path points to a file that does not exist yet, the server starts in config-only mode instead of exiting immediately. After creating or updating config through the config tools, restart the server so it reloads the YAML and exposes the full runtime tool set.
 
 ## Build
 
@@ -185,6 +196,8 @@ On macOS, the wrapper will also try `launchctl getenv SSH_AUTH_SOCK` before fail
 
 Once registered, Codex should be able to use:
 
+- `config_bootstrap` to create the initial YAML config file when it does not exist yet; it writes a minimal valid config and requires a server restart before other tools see the new settings
+- `config_upsert_repo` to add or update one repository entry in the YAML config; it validates the resulting file against the existing schema, matches existing repos by canonical path, and requires a server restart before the runtime config changes take effect
 - `git_repo_policy` to inspect the configured path, canonical path, allowed branch patterns, suggested feature-branch pattern, configured worktree base path, default remote, and draft-PR setting for an allowlisted repository
 - `git_status` for an allowlisted repository
 - `git_add` for repository-relative paths inside an allowlisted repository; it rejects absolute paths and repository-escaping paths like `../x`
@@ -197,6 +210,8 @@ Once registered, Codex should be able to use:
 - `gh_pr_create_draft` to create a draft PR for the current branch using an explicit base or the detected default branch; it is draft-only and requires a non-empty title
 
 Mutating tools reject detached HEAD.
+
+When the config file is missing, only `config_bootstrap` and `config_upsert_repo` are exposed. The Git and GitHub tools are registered only after the server loads a valid runtime config.
 
 ## Remote And Base Resolution
 
@@ -242,4 +257,11 @@ repositories:
     allowed_branch_patterns:
       - "^main$"
 ```
+
+If you want to bootstrap the config and then add this repository incrementally, a minimal progression is:
+
+1. Call `config_bootstrap` with defaults such as `feature_branch_pattern`, `always_allowed_branch_patterns`, or `branching_policies`.
+2. Restart the MCP server.
+3. Call `config_upsert_repo` with `repo_path`, and optionally `git_worktree_base_path`, `default_remote`, `allowed_branch_patterns`, or `branching_policies`.
+4. Restart the MCP server again before using the Git tools against that repository.
 ```

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,7 +2,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 
-import { parse as parseYaml } from "yaml";
+import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
 import { z } from "zod";
 
 import { ConfigError } from "./errors.js";
@@ -30,11 +30,97 @@ const configSchema = z.object({
   repositories: z.array(repoPolicySchema),
 });
 
+export type EditablePolicyDefaults = z.infer<typeof policyDefaultsSchema>;
+export type EditableRepoPolicy = z.infer<typeof repoPolicySchema>;
+export type EditableConfig = z.infer<typeof configSchema>;
+
+export type BootstrapConfigInput = EditablePolicyDefaults & {
+  always_allowed_branch_patterns?: string[];
+};
+
+export type UpsertRepoConfigInput = {
+  repo_path: string;
+} & EditablePolicyDefaults;
+
 export async function loadConfig(configPath: string): Promise<Config> {
   const raw = await fs.readFile(configPath, "utf8");
-  const parsed = parseYaml(raw);
-  const config = configSchema.parse(parsed);
+  const config = parseConfig(raw);
+  return await normalizeConfig(config);
+}
 
+export async function loadOptionalConfig(configPath: string): Promise<Config | undefined> {
+  try {
+    return await loadConfig(configPath);
+  } catch (error) {
+    if (isFileNotFoundError(error)) {
+      return undefined;
+    }
+
+    throw error;
+  }
+}
+
+export async function bootstrapConfig(configPath: string, input: BootstrapConfigInput): Promise<EditableConfig> {
+  if (await configFileExists(configPath)) {
+    throw new ConfigError(`config file '${configPath}' already exists`);
+  }
+
+  const config = sanitizeEditableConfig({
+    defaults: toOptionalPolicyDefaults(input),
+    always_allowed_branch_patterns: input.always_allowed_branch_patterns,
+    repositories: [],
+  });
+
+  await normalizeConfig(config);
+  await writeConfig(configPath, config);
+
+  return config;
+}
+
+export async function upsertRepoConfig(configPath: string, input: UpsertRepoConfigInput): Promise<{
+  action: "created" | "updated";
+  repo: EditableRepoPolicy;
+}> {
+  const config = (await readEditableConfig(configPath)) ?? { repositories: [] };
+  const nextConfig = sanitizeEditableConfig(config);
+  const nextRepo = sanitizeEditableRepo({
+    path: input.repo_path,
+    ...toOptionalPolicyDefaults(input),
+  });
+  const nextRepoCanonicalPath = await resolveConfiguredRepoCanonicalPath(nextRepo.path);
+
+  let action: "created" | "updated" = "created";
+  let updatedRepo = nextRepo;
+  const existingRepoIndex = await findRepoIndexByCanonicalPath(nextConfig.repositories, nextRepoCanonicalPath);
+
+  if (existingRepoIndex >= 0) {
+    action = "updated";
+    const existingRepo = nextConfig.repositories[existingRepoIndex]!;
+    updatedRepo = {
+      ...existingRepo,
+      ...nextRepo,
+      path: existingRepo.path,
+    };
+    nextConfig.repositories[existingRepoIndex] = sanitizeEditableRepo(updatedRepo);
+  } else {
+    nextConfig.repositories.push(nextRepo);
+  }
+
+  await normalizeConfig(nextConfig);
+  await writeConfig(configPath, nextConfig);
+
+  return {
+    action,
+    repo: updatedRepo,
+  };
+}
+
+function parseConfig(raw: string): EditableConfig {
+  const parsed = parseYaml(raw);
+  return configSchema.parse(parsed);
+}
+
+async function normalizeConfig(config: EditableConfig): Promise<Config> {
   const repositories: RepoPolicy[] = [];
   const seenPaths = new Set<string>();
 
@@ -84,6 +170,56 @@ export async function loadConfig(configPath: string): Promise<Config> {
   return { repositories };
 }
 
+async function readEditableConfig(configPath: string): Promise<EditableConfig | undefined> {
+  try {
+    const raw = await fs.readFile(configPath, "utf8");
+    return parseConfig(raw);
+  } catch (error) {
+    if (isFileNotFoundError(error)) {
+      return undefined;
+    }
+
+    throw error;
+  }
+}
+
+async function writeConfig(configPath: string, config: EditableConfig): Promise<void> {
+  await fs.mkdir(path.dirname(configPath), { recursive: true });
+  await fs.writeFile(configPath, `${stringifyYaml(config).trimEnd()}\n`, "utf8");
+}
+
+function sanitizeEditableConfig(input: Partial<EditableConfig>): EditableConfig {
+  return {
+    ...(input.defaults ? { defaults: sanitizePolicyDefaults(input.defaults) } : {}),
+    ...(input.always_allowed_branch_patterns ? { always_allowed_branch_patterns: input.always_allowed_branch_patterns } : {}),
+    repositories: (input.repositories ?? []).map((repo) => sanitizeEditableRepo(repo)),
+  };
+}
+
+function sanitizeEditableRepo(input: EditableRepoPolicy): EditableRepoPolicy {
+  return {
+    path: input.path,
+    ...toOptionalPolicyDefaults(input),
+  };
+}
+
+function sanitizePolicyDefaults(input: EditablePolicyDefaults): EditablePolicyDefaults {
+  return {
+    ...toOptionalPolicyDefaults(input),
+  };
+}
+
+function toOptionalPolicyDefaults(input: Partial<EditablePolicyDefaults>): EditablePolicyDefaults {
+  return {
+    ...(input.allowed_branch_patterns ? { allowed_branch_patterns: input.allowed_branch_patterns } : {}),
+    ...(input.feature_branch_pattern ? { feature_branch_pattern: input.feature_branch_pattern } : {}),
+    ...(input.git_worktree_base_path ? { git_worktree_base_path: input.git_worktree_base_path } : {}),
+    ...(input.default_remote ? { default_remote: input.default_remote } : {}),
+    ...(input.allow_draft_prs !== undefined ? { allow_draft_prs: input.allow_draft_prs } : {}),
+    ...(input.branching_policies ? { branching_policies: input.branching_policies } : {}),
+  };
+}
+
 function resolveBranchingPolicies(
   repoPolicies: BranchingPolicy[] | undefined,
   defaultPolicies: BranchingPolicy[] | undefined,
@@ -105,6 +241,34 @@ function expandHomeDir(inputPath: string): string {
   }
 
   return inputPath;
+}
+
+async function resolveConfiguredRepoCanonicalPath(repoPath: string): Promise<string> {
+  const expandedPath = expandHomeDir(repoPath);
+  if (!path.isAbsolute(expandedPath)) {
+    throw new ConfigError(`repository path '${repoPath}' must be absolute or start with '~/'`);
+  }
+
+  try {
+    return await fs.realpath(expandedPath);
+  } catch (error) {
+    if (isFileNotFoundError(error)) {
+      throw new ConfigError(`repository path '${repoPath}' could not be resolved`);
+    }
+
+    throw error;
+  }
+}
+
+async function findRepoIndexByCanonicalPath(repositories: EditableRepoPolicy[], canonicalPath: string): Promise<number> {
+  for (const [index, repo] of repositories.entries()) {
+    const repoCanonicalPath = await resolveConfiguredRepoCanonicalPath(repo.path);
+    if (repoCanonicalPath === canonicalPath) {
+      return index;
+    }
+  }
+
+  return -1;
 }
 
 async function resolveGitWorktreeBasePath(inputPath: string | undefined): Promise<string | undefined> {
@@ -152,4 +316,21 @@ function compileBranchPatterns(patterns: string[], repoPath: string): RegExp[] {
       );
     }
   });
+}
+
+async function configFileExists(configPath: string): Promise<boolean> {
+  try {
+    await fs.access(configPath);
+    return true;
+  } catch (error) {
+    if (isFileNotFoundError(error)) {
+      return false;
+    }
+
+    throw error;
+  }
+}
+
+function isFileNotFoundError(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error && "code" in error && error.code === "ENOENT";
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 
-import { loadConfig } from "./config.js";
+import { loadOptionalConfig } from "./config.js";
 import { createServer } from "./server.js";
 
 function getConfigPath(argv: string[]): string {
@@ -14,8 +14,8 @@ function getConfigPath(argv: string[]): string {
 
 async function main(): Promise<void> {
   const configPath = getConfigPath(process.argv);
-  const config = await loadConfig(configPath);
-  const server = createServer(config);
+  const config = await loadOptionalConfig(configPath);
+  const server = createServer(configPath, config);
   const transport = new StdioServerTransport();
 
   await server.connect(transport);

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,6 +1,7 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 
+import { bootstrapConfig, upsertRepoConfig } from "./config.js";
 import type { Config } from "./types/config.js";
 import { requireAllowedBranch } from "./auth/branchAuth.js";
 import { resolveAllowedRepo } from "./auth/repoAuth.js";
@@ -15,11 +16,106 @@ import { getGitRepoPolicy } from "./tools/gitRepoPolicy.js";
 import { getGitStatus } from "./tools/gitStatus.js";
 import { gitWorktreeAdd } from "./tools/gitWorktreeAdd.js";
 
-export function createServer(config: Config): McpServer {
+const branchingPoliciesSchema = z.array(z.enum(["worktree", "feature_branch", "current_branch"])).min(1);
+
+const configPolicyFields = {
+  allowed_branch_patterns: z.array(z.string().min(1)).min(1).optional(),
+  feature_branch_pattern: z.string().min(1).optional(),
+  git_worktree_base_path: z.string().min(1).optional(),
+  default_remote: z.string().min(1).optional(),
+  allow_draft_prs: z.boolean().optional(),
+  branching_policies: branchingPoliciesSchema.optional(),
+};
+
+export function getRegisteredToolNames(hasRuntimeConfig: boolean): string[] {
+  const configToolNames = ["config_bootstrap", "config_upsert_repo"];
+  if (!hasRuntimeConfig) {
+    return configToolNames;
+  }
+
+  return [
+    ...configToolNames,
+    "git_repo_policy",
+    "git_status",
+    "git_add",
+    "git_commit",
+    "git_branch_create_and_switch",
+    "git_branch_switch",
+    "git_fetch",
+    "git_worktree_add",
+    "git_push",
+    "gh_pr_create_draft",
+  ];
+}
+
+export function createServer(configPath: string, config?: Config): McpServer {
   const server = new McpServer({
     name: "codex-git-unleash-mcp",
     version: "0.1.0",
   });
+
+  server.tool(
+    "config_bootstrap",
+    "Create the initial MCP config file when it does not yet exist. This tool writes a minimal valid YAML config and does not apply changes to the current server process; restart the MCP server after use.",
+    {
+      ...configPolicyFields,
+      always_allowed_branch_patterns: z.array(z.string().min(1)).min(1).optional(),
+    },
+    async (input) => {
+      const nextConfig = await bootstrapConfig(configPath, input);
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(
+              {
+                configPath,
+                repositories: nextConfig.repositories.length,
+                restartRequired: true,
+              },
+              null,
+              2,
+            ),
+          },
+        ],
+      };
+    },
+  );
+
+  server.tool(
+    "config_upsert_repo",
+    "Add or update one repository entry in the MCP config file. This tool validates the resulting YAML against the existing schema and does not hot-reload the current server process; restart the MCP server after use.",
+    {
+      repo_path: z.string().min(1),
+      ...configPolicyFields,
+    },
+    async (input) => {
+      const result = await upsertRepoConfig(configPath, input);
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(
+              {
+                configPath,
+                action: result.action,
+                repo: result.repo,
+                restartRequired: true,
+              },
+              null,
+              2,
+            ),
+          },
+        ],
+      };
+    },
+  );
+
+  if (!config) {
+    return server;
+  }
 
   server.tool(
     "git_repo_policy",

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -4,7 +4,8 @@ import path from "node:path";
 
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { loadConfig } from "../src/config.js";
+import { bootstrapConfig, loadConfig, loadOptionalConfig, upsertRepoConfig } from "../src/config.js";
+import { ConfigError } from "../src/errors.js";
 
 const tempPaths: string[] = [];
 
@@ -268,5 +269,129 @@ describe("loadConfig", () => {
     await expect(loadConfig(configPath)).rejects.toThrow(
       "git_worktree_base_path 'tmp/worktrees' must be absolute or start with '~/'",
     );
+  });
+
+  it("returns undefined for a missing optional config file", async () => {
+    const configPath = path.join(os.tmpdir(), `git-mcp-config-${Date.now()}-missing.yaml`);
+    tempPaths.push(configPath);
+
+    await expect(loadOptionalConfig(configPath)).resolves.toBeUndefined();
+  });
+});
+
+describe("bootstrapConfig", () => {
+  it("creates a minimal valid config file", async () => {
+    const configPath = path.join(os.tmpdir(), `git-mcp-config-${Date.now()}-bootstrap.yaml`);
+    tempPaths.push(configPath);
+
+    const result = await bootstrapConfig(configPath, {
+      feature_branch_pattern: "dm/<feature-name>",
+      always_allowed_branch_patterns: ["^dm\\/.*$"],
+      allow_draft_prs: true,
+    });
+
+    expect(result).toEqual({
+      defaults: {
+        feature_branch_pattern: "dm/<feature-name>",
+        allow_draft_prs: true,
+      },
+      always_allowed_branch_patterns: ["^dm\\/.*$"],
+      repositories: [],
+    });
+
+    await expect(loadConfig(configPath)).resolves.toEqual({ repositories: [] });
+  });
+
+  it("refuses to overwrite an existing config file", async () => {
+    const configPath = path.join(os.tmpdir(), `git-mcp-config-${Date.now()}-bootstrap-existing.yaml`);
+    tempPaths.push(configPath);
+    await fs.writeFile(configPath, "repositories: []\n", "utf8");
+
+    await expect(bootstrapConfig(configPath, {})).rejects.toEqual(
+      new ConfigError(`config file '${configPath}' already exists`),
+    );
+  });
+});
+
+describe("upsertRepoConfig", () => {
+  it("creates a new config file with one repo when the config is missing", async () => {
+    const repoDir = await fs.mkdtemp(path.join(os.tmpdir(), "git-mcp-upsert-create-repo-"));
+    const configPath = path.join(os.tmpdir(), `git-mcp-config-${Date.now()}-upsert-create.yaml`);
+    tempPaths.push(repoDir, configPath);
+
+    const result = await upsertRepoConfig(configPath, {
+      repo_path: repoDir,
+      allowed_branch_patterns: ["^dm\\/.*$"],
+      branching_policies: ["worktree"],
+    });
+
+    expect(result).toEqual({
+      action: "created",
+      repo: {
+        path: repoDir,
+        allowed_branch_patterns: ["^dm\\/.*$"],
+        branching_policies: ["worktree"],
+      },
+    });
+
+    const config = await loadConfig(configPath);
+    expect(config.repositories).toHaveLength(1);
+    expect(config.repositories[0]?.path).toBe(repoDir);
+    expect(config.repositories[0]?.branchingPolicies).toEqual(["worktree"]);
+  });
+
+  it("updates an existing repo entry matched by canonical path", async () => {
+    const repoParentDir = await fs.mkdtemp(path.join(os.tmpdir(), "git-mcp-upsert-update-parent-"));
+    const repoDir = path.join(repoParentDir, "repo");
+    const aliasDir = path.join(repoParentDir, "repo-alias");
+    const configPath = path.join(os.tmpdir(), `git-mcp-config-${Date.now()}-upsert-update.yaml`);
+    tempPaths.push(repoParentDir, configPath);
+
+    await fs.mkdir(repoDir);
+    await fs.symlink(repoDir, aliasDir);
+    await fs.writeFile(
+      configPath,
+      [
+        "repositories:",
+        `  - path: ${repoDir}`,
+        "    allowed_branch_patterns:",
+        '      - "^dm\\/.*$"',
+      ].join("\n"),
+      "utf8",
+    );
+
+    const result = await upsertRepoConfig(configPath, {
+      repo_path: aliasDir,
+      default_remote: "origin",
+      branching_policies: ["worktree"],
+    });
+
+    expect(result).toEqual({
+      action: "updated",
+      repo: {
+        path: repoDir,
+        allowed_branch_patterns: ["^dm/.*$"],
+        default_remote: "origin",
+        branching_policies: ["worktree"],
+      },
+    });
+
+    const nextConfig = await loadConfig(configPath);
+    expect(nextConfig.repositories).toHaveLength(1);
+    expect(nextConfig.repositories[0]?.defaultRemote).toBe("origin");
+    expect(nextConfig.repositories[0]?.branchingPolicies).toEqual(["worktree"]);
+  });
+
+  it("rejects invalid branch regex updates", async () => {
+    const repoDir = await fs.mkdtemp(path.join(os.tmpdir(), "git-mcp-upsert-invalid-regex-repo-"));
+    const configPath = path.join(os.tmpdir(), `git-mcp-config-${Date.now()}-upsert-invalid-regex.yaml`);
+    tempPaths.push(repoDir, configPath);
+
+    await expect(
+      upsertRepoConfig(configPath, {
+        repo_path: repoDir,
+        allowed_branch_patterns: ["["],
+      }),
+    ).rejects.toThrow(`invalid branch regex '[' for repository '${repoDir}'`);
   });
 });

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+
+import { getRegisteredToolNames } from "../src/server.js";
+
+describe("getRegisteredToolNames", () => {
+  it("returns only config tools when runtime config is unavailable", () => {
+    expect(getRegisteredToolNames(false)).toEqual(["config_bootstrap", "config_upsert_repo"]);
+  });
+
+  it("returns config and git tools when runtime config is available", () => {
+    expect(getRegisteredToolNames(true)).toEqual([
+      "config_bootstrap",
+      "config_upsert_repo",
+      "git_repo_policy",
+      "git_status",
+      "git_add",
+      "git_commit",
+      "git_branch_create_and_switch",
+      "git_branch_switch",
+      "git_fetch",
+      "git_worktree_add",
+      "git_push",
+      "gh_pr_create_draft",
+    ]);
+  });
+});


### PR DESCRIPTION
## Why
The server currently exits before it can expose any tools when the configured YAML file does not exist. That makes first-time setup depend on manual config authoring and blocks the config management workflow proposed in issue #32.

This change adds a constrained bootstrap path so the MCP server can start without a runtime config, create an initial config file, and upsert a single repository entry using the existing schema and validation rules.

## Impact
Users can bootstrap a missing config and add or update one repo entry without hand-editing YAML. The normal Git and GitHub tool surface still stays behind a valid loaded config, so the policy boundary remains narrow.

Config edits in this first version do not hot-reload the running server. The tool responses make the restart requirement explicit, and YAML formatting may be normalized on write.

## Validation
- npm run typecheck
- npm test