### PR TITLE
[feature] reload config in runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ npm install
 
 Use a config file at `~/.config/codex-git-unleash-mcp.yaml`.
 
-If that file does not exist yet, the server can still start in a limited config-only mode. In that mode it exposes `config_bootstrap` and `config_upsert_repo` so you can create the initial YAML and add repository entries before enabling the full Git and GitHub tool surface.
+If that file does not exist yet, the server still starts and exposes the full tool surface. `config_bootstrap` and `config_upsert_repo` can create or update the YAML, and the runtime Git/GitHub tools will pick up the changed config on the next tool call.
 
 Example:
 
@@ -81,7 +81,7 @@ Notes:
 - `path` must be an absolute path or start with `~/`
 - `config_bootstrap` creates a minimal valid YAML config file and refuses to overwrite an existing file
 - `config_upsert_repo` adds or updates one repository entry in the YAML config and matches existing entries by canonical repository path
-- config changes do not hot-reload the running server in this version; restart the MCP server after calling `config_bootstrap` or `config_upsert_repo`
+- config changes are reloaded from disk on the next tool call, so a server restart is not required after `config_bootstrap` or `config_upsert_repo`
 - top-level `defaults` are optional and may define `allowed_branch_patterns`, `feature_branch_pattern`, `git_worktree_base_path`, `default_remote`, `allow_draft_prs`, and `branching_policies`
 - top-level `always_allowed_branch_patterns` are optional and are appended to every repository's effective branch policy
 - repository values override top-level defaults field-by-field
@@ -111,8 +111,8 @@ Notes:
 
 The intended happy path is:
 
-1. If the config file does not exist yet, call `config_bootstrap` to create it, then restart the MCP server.
-2. Call `config_upsert_repo` to add or update an allowlisted repository entry when needed, then restart the MCP server.
+1. If the config file does not exist yet, call `config_bootstrap` to create it.
+2. Call `config_upsert_repo` to add or update an allowlisted repository entry when needed.
 3. Call `git_repo_policy` or `git_status` to inspect the allowlisted repository.
 4. Before creating a branch, use `git_repo_policy` to confirm the configured `allowed_branch_patterns`, then choose a new branch name that matches that policy.
 5. Call `git_branch_create_and_switch` to branch from an explicit or detected upstream base when you need a new local branch in the current worktree.
@@ -138,7 +138,7 @@ You can also provide the config path through `GIT_UNLEASH_MCP_CONFIG`:
 GIT_UNLEASH_MCP_CONFIG=~/.config/codex-git-unleash-mcp.yaml npm run dev
 ```
 
-If the config path points to a file that does not exist yet, the server starts in config-only mode instead of exiting immediately. After creating or updating config through the config tools, restart the server so it reloads the YAML and exposes the full runtime tool set.
+If the config path points to a file that does not exist yet, the server still starts. Runtime tools that need an allowlist will fail with a config guidance error until you create or update the YAML, and they will pick up the file on the next tool call.
 
 ## Build
 
@@ -196,8 +196,8 @@ On macOS, the wrapper will also try `launchctl getenv SSH_AUTH_SOCK` before fail
 
 Once registered, Codex should be able to use:
 
-- `config_bootstrap` to create the initial YAML config file when it does not exist yet; it writes a minimal valid config and requires a server restart before other tools see the new settings
-- `config_upsert_repo` to add or update one repository entry in the YAML config; it validates the resulting file against the existing schema, matches existing repos by canonical path, and requires a server restart before the runtime config changes take effect
+- `config_bootstrap` to create the initial YAML config file when it does not exist yet; it writes a minimal valid config and the runtime tool handlers will see it on their next call
+- `config_upsert_repo` to add or update one repository entry in the YAML config; it validates the resulting file against the existing schema, matches existing repos by canonical path, and the runtime tool handlers will see the updated policy on their next call
 - `git_repo_policy` to inspect the configured path, canonical path, allowed branch patterns, suggested feature-branch pattern, configured worktree base path, default remote, and draft-PR setting for an allowlisted repository
 - `git_status` for an allowlisted repository
 - `git_add` for repository-relative paths inside an allowlisted repository; it rejects absolute paths and repository-escaping paths like `../x`
@@ -211,7 +211,7 @@ Once registered, Codex should be able to use:
 
 Mutating tools reject detached HEAD.
 
-When the config file is missing, only `config_bootstrap` and `config_upsert_repo` are exposed. The Git and GitHub tools are registered only after the server loads a valid runtime config.
+When the config file is missing, runtime tools remain registered but fail with a guidance error until the config is created. Once the YAML exists, the next tool call reloads it from disk.
 
 ## Remote And Base Resolution
 
@@ -261,7 +261,6 @@ repositories:
 If you want to bootstrap the config and then add this repository incrementally, a minimal progression is:
 
 1. Call `config_bootstrap` with defaults such as `feature_branch_pattern`, `always_allowed_branch_patterns`, or `branching_policies`.
-2. Restart the MCP server.
-3. Call `config_upsert_repo` with `repo_path`, and optionally `git_worktree_base_path`, `default_remote`, `allowed_branch_patterns`, or `branching_policies`.
-4. Restart the MCP server again before using the Git tools against that repository.
+2. Call `config_upsert_repo` with `repo_path`, and optionally `git_worktree_base_path`, `default_remote`, `allowed_branch_patterns`, or `branching_policies`.
+3. Use the Git tools against that repository; they will reload the YAML on each call.
 ```

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,5 @@
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 
-import { loadOptionalConfig } from "./config.js";
 import { createServer } from "./server.js";
 
 function getConfigPath(argv: string[]): string {
@@ -14,8 +13,7 @@ function getConfigPath(argv: string[]): string {
 
 async function main(): Promise<void> {
   const configPath = getConfigPath(process.argv);
-  const config = await loadOptionalConfig(configPath);
-  const server = createServer(configPath, config);
+  const server = createServer(configPath);
   const transport = new StdioServerTransport();
 
   await server.connect(transport);

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,8 +1,8 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 
-import { bootstrapConfig, upsertRepoConfig } from "./config.js";
-import type { Config } from "./types/config.js";
+import { bootstrapConfig, loadOptionalConfig, upsertRepoConfig } from "./config.js";
+import { ConfigError } from "./errors.js";
 import { requireAllowedBranch } from "./auth/branchAuth.js";
 import { resolveAllowedRepo } from "./auth/repoAuth.js";
 import { gitAdd } from "./tools/gitAdd.js";
@@ -27,14 +27,10 @@ const configPolicyFields = {
   branching_policies: branchingPoliciesSchema.optional(),
 };
 
-export function getRegisteredToolNames(hasRuntimeConfig: boolean): string[] {
-  const configToolNames = ["config_bootstrap", "config_upsert_repo"];
-  if (!hasRuntimeConfig) {
-    return configToolNames;
-  }
-
+export function getRegisteredToolNames(): string[] {
   return [
-    ...configToolNames,
+    "config_bootstrap",
+    "config_upsert_repo",
     "git_repo_policy",
     "git_status",
     "git_add",
@@ -48,7 +44,18 @@ export function getRegisteredToolNames(hasRuntimeConfig: boolean): string[] {
   ];
 }
 
-export function createServer(configPath: string, config?: Config): McpServer {
+export async function loadRuntimeConfig(configPath: string) {
+  const config = await loadOptionalConfig(configPath);
+  if (!config) {
+    throw new ConfigError(
+      `config file '${configPath}' does not exist; call 'config_bootstrap' to create it or 'config_upsert_repo' to create it with a repository entry`,
+    );
+  }
+
+  return config;
+}
+
+export function createServer(configPath: string): McpServer {
   const server = new McpServer({
     name: "codex-git-unleash-mcp",
     version: "0.1.0",
@@ -113,10 +120,6 @@ export function createServer(configPath: string, config?: Config): McpServer {
     },
   );
 
-  if (!config) {
-    return server;
-  }
-
   server.tool(
     "git_repo_policy",
     "Return the configured policy for an allowlisted repository. This tool is read-only and exposes the branch patterns and related repository defaults that other tools enforce.",
@@ -124,6 +127,7 @@ export function createServer(configPath: string, config?: Config): McpServer {
       repo_path: z.string().min(1),
     },
     async ({ repo_path }) => {
+      const config = await loadRuntimeConfig(configPath);
       const repo = await resolveAllowedRepo(config, repo_path);
       const result = getGitRepoPolicy(repo);
 
@@ -145,6 +149,7 @@ export function createServer(configPath: string, config?: Config): McpServer {
       repo_path: z.string().min(1),
     },
     async ({ repo_path }) => {
+      const config = await loadRuntimeConfig(configPath);
       const repo = await resolveAllowedRepo(config, repo_path);
       const status = await getGitStatus(repo);
 
@@ -167,6 +172,7 @@ export function createServer(configPath: string, config?: Config): McpServer {
       paths: z.array(z.string().min(1)).min(1),
     },
     async ({ repo_path, paths }) => {
+      const config = await loadRuntimeConfig(configPath);
       const repo = await resolveAllowedRepo(config, repo_path);
       await requireAllowedBranch(repo);
       const result = await gitAdd(repo, paths);
@@ -190,6 +196,7 @@ export function createServer(configPath: string, config?: Config): McpServer {
       message: z.string(),
     },
     async ({ repo_path, message }) => {
+      const config = await loadRuntimeConfig(configPath);
       const repo = await resolveAllowedRepo(config, repo_path);
       await requireAllowedBranch(repo);
       const result = await gitCommit(repo, message);
@@ -214,6 +221,7 @@ export function createServer(configPath: string, config?: Config): McpServer {
       branch: z.string().min(1).optional(),
     },
     async ({ repo_path, new_branch, branch }) => {
+      const config = await loadRuntimeConfig(configPath);
       const repo = await resolveAllowedRepo(config, repo_path);
       const result = await gitBranchCreateAndSwitch(repo, { newBranch: new_branch, branch });
 
@@ -236,6 +244,7 @@ export function createServer(configPath: string, config?: Config): McpServer {
       branch: z.string(),
     },
     async ({ repo_path, branch }) => {
+      const config = await loadRuntimeConfig(configPath);
       const repo = await resolveAllowedRepo(config, repo_path);
       const result = await gitBranchSwitch(repo, branch);
 
@@ -258,6 +267,7 @@ export function createServer(configPath: string, config?: Config): McpServer {
       branch: z.string().optional(),
     },
     async ({ repo_path, branch }) => {
+      const config = await loadRuntimeConfig(configPath);
       const repo = await resolveAllowedRepo(config, repo_path);
       const result = await gitFetch(repo, { branch });
 
@@ -282,6 +292,7 @@ export function createServer(configPath: string, config?: Config): McpServer {
       branch: z.string().min(1).optional(),
     },
     async ({ repo_path, path, new_branch, branch }) => {
+      const config = await loadRuntimeConfig(configPath);
       const repo = await resolveAllowedRepo(config, repo_path);
       const result = await gitWorktreeAdd(repo, { path, newBranch: new_branch, branch });
 
@@ -303,6 +314,7 @@ export function createServer(configPath: string, config?: Config): McpServer {
       repo_path: z.string().min(1),
     },
     async ({ repo_path }) => {
+      const config = await loadRuntimeConfig(configPath);
       const repo = await resolveAllowedRepo(config, repo_path);
       const branch = await requireAllowedBranch(repo);
       const result = await gitPush(repo, branch);
@@ -328,6 +340,7 @@ export function createServer(configPath: string, config?: Config): McpServer {
       base: z.string().min(1).optional(),
     },
     async ({ repo_path, title, body, base }) => {
+      const config = await loadRuntimeConfig(configPath);
       const repo = await resolveAllowedRepo(config, repo_path);
       const branch = await requireAllowedBranch(repo);
       const result = await ghPrCreateDraft(repo, branch, { title, body, base });

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -1,14 +1,21 @@
-import { describe, expect, it } from "vitest";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 
-import { getRegisteredToolNames } from "../src/server.js";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { ConfigError } from "../src/errors.js";
+import { getRegisteredToolNames, loadRuntimeConfig } from "../src/server.js";
+
+const tempPaths: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempPaths.splice(0).map((tempPath) => fs.rm(tempPath, { force: true, recursive: true })));
+});
 
 describe("getRegisteredToolNames", () => {
-  it("returns only config tools when runtime config is unavailable", () => {
-    expect(getRegisteredToolNames(false)).toEqual(["config_bootstrap", "config_upsert_repo"]);
-  });
-
-  it("returns config and git tools when runtime config is available", () => {
-    expect(getRegisteredToolNames(true)).toEqual([
+  it("always returns the full tool surface", () => {
+    expect(getRegisteredToolNames()).toEqual([
       "config_bootstrap",
       "config_upsert_repo",
       "git_repo_policy",
@@ -22,5 +29,53 @@ describe("getRegisteredToolNames", () => {
       "git_push",
       "gh_pr_create_draft",
     ]);
+  });
+});
+
+describe("loadRuntimeConfig", () => {
+  it("reloads config from disk for each call", async () => {
+    const repoDir = await fs.mkdtemp(path.join(os.tmpdir(), "git-mcp-runtime-reload-repo-"));
+    const configPath = path.join(os.tmpdir(), `git-mcp-runtime-reload-${Date.now()}.yaml`);
+    tempPaths.push(repoDir, configPath);
+
+    await fs.writeFile(
+      configPath,
+      [
+        "repositories:",
+        `  - path: ${repoDir}`,
+        "    allowed_branch_patterns:",
+        '      - "^main$"',
+      ].join("\n"),
+      "utf8",
+    );
+
+    const firstConfig = await loadRuntimeConfig(configPath);
+    expect(firstConfig.repositories[0]?.defaultRemote).toBeUndefined();
+
+    await fs.writeFile(
+      configPath,
+      [
+        "repositories:",
+        `  - path: ${repoDir}`,
+        "    allowed_branch_patterns:",
+        '      - "^main$"',
+        "    default_remote: upstream",
+      ].join("\n"),
+      "utf8",
+    );
+
+    const secondConfig = await loadRuntimeConfig(configPath);
+    expect(secondConfig.repositories[0]?.defaultRemote).toBe("upstream");
+  });
+
+  it("raises a config error with bootstrap guidance when the file is missing", async () => {
+    const configPath = path.join(os.tmpdir(), `git-mcp-runtime-missing-${Date.now()}.yaml`);
+    tempPaths.push(configPath);
+
+    await expect(loadRuntimeConfig(configPath)).rejects.toEqual(
+      new ConfigError(
+        `config file '${configPath}' does not exist; call 'config_bootstrap' to create it or 'config_upsert_repo' to create it with a repository entry`,
+      ),
+    );
   });
 });


### PR DESCRIPTION
## Why
The config bootstrap work landed with an explicit restart requirement because the server captured the YAML once at startup and only registered the runtime Git/GitHub tools when that snapshot existed. Issue #34 asks for the MCP server to notice config changes at runtime, including the simple path of rereading the file for each tool operation.

This change moves runtime config resolution into the tool handlers themselves so `config_bootstrap` and `config_upsert_repo` take effect on the next call without restarting the server process.

## Impact
Config changes now hot-apply on the next tool invocation, and the full tool surface stays registered even when the config file is initially missing. Runtime tools fail with an explicit guidance error until the YAML exists, then immediately start using the updated allowlist and policy values.

The tradeoff is an extra config-file read and validation pass per runtime tool call. Given the small config size and the issue request, that simplicity is preferable to introducing a cache invalidation path.

## Validation
- npm run typecheck
- npm test