### PR TITLE
Support <user> in allowed branch patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ defaults:
     - worktree
 
 always_allowed_branch_patterns:
-  - "^user/.*$"
+  - "^<user>/.*$"
 
 repositories:
   - path: ~/projects/codex-git-unleash-mcp
@@ -87,7 +87,7 @@ Notes:
 - repository values override top-level defaults field-by-field
 - `defaults.allowed_branch_patterns` are inherited or overridden, while `always_allowed_branch_patterns` are always added
 - `feature_branch_pattern` is an optional suggested naming template for new feature branches; it is advisory metadata and does not grant permission to use a branch name that fails `allowed_branch_patterns`
-- `feature_branch_pattern` supports a dedicated `<user>` placeholder, resolved from `USER`, then `USERNAME`, then the system account username; other environment-variable expansion is intentionally not supported
+- `allowed_branch_patterns`, `always_allowed_branch_patterns`, and `feature_branch_pattern` support a dedicated `<user>` placeholder, resolved from `USER`, then `USERNAME`, then the system account username; other environment-variable expansion is intentionally not supported
 - `git_worktree_base_path` is inherited or overridden per repository and, when configured, constrains `git_worktree_add.path` to stay under that base
 - for Codex workflows, prefer a repo-specific in-repository worktree base such as `.worktrees/` when you want linked worktrees to stay under the same trusted project root; add that directory to `.gitignore`
 - `branching_policies` is optional and enforced for branch-setup tools; supported values are `worktree`, `feature_branch`, and `current_branch`

--- a/src/config.ts
+++ b/src/config.ts
@@ -230,11 +230,15 @@ function resolveBranchingPolicies(
 }
 
 function resolveFeatureBranchPattern(pattern: string | undefined): string | undefined {
-  if (!pattern?.includes("<user>")) {
-    return pattern;
+  return resolveUserPlaceholder(pattern);
+}
+
+function resolveUserPlaceholder(value: string | undefined): string | undefined {
+  if (!value?.includes("<user>")) {
+    return value;
   }
 
-  return pattern.replaceAll("<user>", resolveRuntimeUsername());
+  return value.replaceAll("<user>", resolveRuntimeUsername());
 }
 
 function resolveRuntimeUsername(): string {
@@ -252,7 +256,7 @@ function resolveRuntimeUsername(): string {
     // Ignore lookup failures and fall through to a config error below.
   }
 
-  throw new ConfigError("feature_branch_pattern uses '<user>' but no runtime username could be determined");
+  throw new ConfigError("config uses '<user>' but no runtime username could be determined");
 }
 
 function firstNonEmptyValue(...values: Array<string | undefined>): string | undefined {
@@ -345,11 +349,13 @@ async function canonicalizeProspectivePath(inputPath: string): Promise<string> {
 
 function compileBranchPatterns(patterns: string[], repoPath: string): RegExp[] {
   return patterns.map((pattern) => {
+    const resolvedPattern = resolveUserPlaceholder(pattern) ?? pattern;
+
     try {
-      return new RegExp(pattern);
+      return new RegExp(resolvedPattern);
     } catch (error) {
       throw new ConfigError(
-        `invalid branch regex '${pattern}' for repository '${repoPath}': ${
+        `invalid branch regex '${resolvedPattern}' for repository '${repoPath}': ${
           error instanceof Error ? error.message : String(error)
         }`,
       );

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -99,6 +99,30 @@ describe("loadConfig", () => {
     expect(config.repositories[0]?.featureBranchPattern).toBe("codex/<feature-name>");
   });
 
+  it("resolves <user> in inherited allowed branch patterns from USER", async () => {
+    const repoDir = await fs.mkdtemp(path.join(os.tmpdir(), "git-mcp-user-allowed-pattern-repo-"));
+    const configPath = path.join(os.tmpdir(), `git-mcp-config-${Date.now()}-user-allowed-pattern.yaml`);
+    tempPaths.push(repoDir, configPath);
+    vi.stubEnv("USER", "codex");
+    vi.stubEnv("USERNAME", "");
+
+    await fs.writeFile(
+      configPath,
+      [
+        "defaults:",
+        "  allowed_branch_patterns:",
+        '    - "^<user>/.+$"',
+        "repositories:",
+        `  - path: ${repoDir}`,
+      ].join("\n"),
+      "utf8",
+    );
+
+    const config = await loadConfig(configPath);
+
+    expect(config.repositories[0]?.allowedBranchPatterns.map((pattern) => pattern.source)).toEqual(["^codex\\/.+$"]);
+  });
+
   it("falls back to USERNAME before os.userInfo for <user> resolution", async () => {
     const repoDir = await fs.mkdtemp(path.join(os.tmpdir(), "git-mcp-username-pattern-repo-"));
     const configPath = path.join(os.tmpdir(), `git-mcp-config-${Date.now()}-username-pattern.yaml`);
@@ -156,7 +180,30 @@ describe("loadConfig", () => {
     expect(config.repositories[0]?.featureBranchPattern).toBe("system-user/<feature-name>");
   });
 
-  it("rejects <user> feature branch patterns when no runtime username can be determined", async () => {
+  it("resolves <user> in always-allowed branch patterns", async () => {
+    const repoDir = await fs.mkdtemp(path.join(os.tmpdir(), "git-mcp-global-user-pattern-repo-"));
+    const configPath = path.join(os.tmpdir(), `git-mcp-config-${Date.now()}-global-user-pattern.yaml`);
+    tempPaths.push(repoDir, configPath);
+    vi.stubEnv("USER", "codex");
+    vi.stubEnv("USERNAME", "");
+
+    await fs.writeFile(
+      configPath,
+      [
+        'always_allowed_branch_patterns:',
+        '  - "^<user>/.+$"',
+        "repositories:",
+        `  - path: ${repoDir}`,
+      ].join("\n"),
+      "utf8",
+    );
+
+    const config = await loadConfig(configPath);
+
+    expect(config.repositories[0]?.allowedBranchPatterns.map((pattern) => pattern.source)).toEqual(["^codex\\/.+$"]);
+  });
+
+  it("rejects <user> config values when no runtime username can be determined", async () => {
     const repoDir = await fs.mkdtemp(path.join(os.tmpdir(), "git-mcp-missing-user-pattern-repo-"));
     const configPath = path.join(os.tmpdir(), `git-mcp-config-${Date.now()}-missing-user-pattern.yaml`);
     tempPaths.push(repoDir, configPath);
@@ -172,15 +219,13 @@ describe("loadConfig", () => {
         "repositories:",
         `  - path: ${repoDir}`,
         "    allowed_branch_patterns:",
-        '      - "^feature/.+$"',
+        '      - "^<user>/.+$"',
         '    feature_branch_pattern: "<user>/<feature-name>"',
       ].join("\n"),
       "utf8",
     );
 
-    await expect(loadConfig(configPath)).rejects.toThrow(
-      "feature_branch_pattern uses '<user>' but no runtime username could be determined",
-    );
+    await expect(loadConfig(configPath)).rejects.toThrow("config uses '<user>' but no runtime username could be determined");
   });
 
   it("appends always-allowed branch patterns to repository policy", async () => {


### PR DESCRIPTION
## Why
Issue #38 already introduced `<user>` support for `feature_branch_pattern`, but branch authorization still compiled `allowed_branch_patterns` and `always_allowed_branch_patterns` literally. That left the suggested branch name and the enforced branch policy out of sync for configs that wanted a per-user branch prefix.

This change resolves the same dedicated `<user>` placeholder in branch regex sources before compilation, using the same runtime username lookup order as the feature-branch template.

## Impact
Configs can now use `<user>` consistently across both branch naming guidance and branch authorization, including inherited defaults and always-allowed patterns. The main risk is limited to configs that intentionally wanted the literal string `<user>` in a regex, which is unlikely given the existing placeholder semantics and the documented dedicated-token behavior.

Closes #38