### PR TITLE
Allow repo-local overrides on top of global policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,17 @@ Repo-local policy rules:
 - in a fork, the fork's own base branch is authoritative for repo-local policy
 - this prevents locally widened repo-local policy from being used for MCP operations
 
+Example overlay on top of a globally allowlisted repository:
+
+```yaml
+feature_branch_pattern: "<user>/<feature-name>"
+git_worktree_base_path: .worktrees
+branching_policies:
+  - worktree
+```
+
+In that mode, `allowed_branch_patterns` still come from the global config.
+
 ## Workflow Summary
 
 The intended happy path is:

--- a/README.md
+++ b/README.md
@@ -140,6 +140,21 @@ Repo-local policy rules:
 
 Example overlay on top of a globally allowlisted repository:
 
+Global config:
+
+```yaml
+repositories:
+  - path: /Users/alice/project
+    allowed_branch_patterns:
+      - "^alice/.*$"
+    feature_branch_pattern: "alice/<feature-name>"
+    allow_draft_prs: true
+    branching_policies:
+      - feature_branch
+```
+
+Repo-local `.git-unleash.yaml`:
+
 ```yaml
 feature_branch_pattern: "<user>/<feature-name>"
 git_worktree_base_path: .worktrees
@@ -147,7 +162,24 @@ branching_policies:
   - worktree
 ```
 
-In that mode, `allowed_branch_patterns` still come from the global config.
+Effective policy returned by `git_repo_policy`:
+
+```json
+{
+  "allowedBranchPatterns": [
+    "^alice/.*$"
+  ],
+  "featureBranchPattern": "alice/<feature-name>",
+  "gitWorktreeBasePath": "/Users/alice/project/.worktrees",
+  "allowDraftPrs": true,
+  "branchingPolicies": [
+    "worktree"
+  ],
+  "policySource": "repo_local"
+}
+```
+
+In that mode, `allowed_branch_patterns` and other non-overridable fields still come from the global config.
 
 ## Workflow Summary
 

--- a/README.md
+++ b/README.md
@@ -127,8 +127,11 @@ branching_policies:
 
 Repo-local policy rules:
 
-- `.git-unleash.yaml` takes precedence over global config for the same repository
+- `.git-unleash.yaml` takes precedence over global config for the same repository, but globally allowlisted repositories treat it as a limited override layer rather than a full replacement
 - global config still works as a fallback when a repository does not define `.git-unleash.yaml`
+- zero-setup repo-local policy must set `allowed_branch_patterns`
+- when overriding a globally allowlisted repository, repo-local policy may override `feature_branch_pattern`, `git_worktree_base_path`, `allow_draft_prs`, and `branching_policies`
+- when overriding a globally allowlisted repository, repo-local policy must not set `allowed_branch_patterns`
 - for repo-local policy, `git_worktree_base_path` may be relative to the repository root
 - repo-local policy must not set `default_remote`
 - runtime tools fetch the trusted base branch of the current repository instance, compare the repo-local policy in base, index, and working tree, and fail closed on any divergence

--- a/README.md
+++ b/README.md
@@ -181,6 +181,16 @@ Effective policy returned by `git_repo_policy`:
 
 In that mode, `allowed_branch_patterns` and other non-overridable fields still come from the global config.
 
+For example, this repo-local override is rejected because `allowed_branch_patterns` is not overridable for a globally allowlisted repository:
+
+```yaml
+feature_branch_pattern: "<user>/<feature-name>"
+allowed_branch_patterns:
+  - "^[a-zA-Z0-9.]/.*$"
+```
+
+The current implementation treats that as a configuration error instead of trying to merge or replace the global branch authorization rules.
+
 ## Workflow Summary
 
 The intended happy path is:

--- a/src/auth/repoAuth.ts
+++ b/src/auth/repoAuth.ts
@@ -13,7 +13,8 @@ export async function resolveAllowedRepo(config: Config, repoPath: string): Prom
     throw new RepoNotAllowedError(absolutePath);
   }
 
-  const repoLocalPolicy = await loadRepoLocalPolicy(resolvedRepo.topLevel);
+  const repo = await findMatchingRepo(config, resolvedRepo.commonDir);
+  const repoLocalPolicy = await loadRepoLocalPolicy(resolvedRepo.topLevel, repo);
   if (repoLocalPolicy) {
     return {
       ...repoLocalPolicy,
@@ -21,7 +22,6 @@ export async function resolveAllowedRepo(config: Config, repoPath: string): Prom
     };
   }
 
-  const repo = await findMatchingRepo(config, resolvedRepo.commonDir);
   if (repo) {
     return {
       ...repo,

--- a/src/config.ts
+++ b/src/config.ts
@@ -27,7 +27,7 @@ const repoPolicySchema = policyDefaultsSchema.extend({
 });
 
 const repoLocalPolicySchema = z.object({
-  allowed_branch_patterns: z.array(z.string().min(1)).nonempty(),
+  allowed_branch_patterns: z.array(z.string().min(1)).nonempty().optional(),
   feature_branch_pattern: z.string().min(1).optional(),
   git_worktree_base_path: z.string().min(1).optional(),
   default_remote: z.string().min(1).optional(),
@@ -71,7 +71,7 @@ export async function loadOptionalConfig(configPath: string): Promise<Config | u
   }
 }
 
-export async function loadRepoLocalPolicy(repoRoot: string): Promise<RepoPolicy | undefined> {
+export async function loadRepoLocalPolicy(repoRoot: string, basePolicy?: RepoPolicy): Promise<RepoPolicy | undefined> {
   const canonicalRepoRoot = await fs.realpath(repoRoot);
   const configPath = path.join(canonicalRepoRoot, REPO_LOCAL_CONFIG_FILENAME);
 
@@ -101,6 +101,33 @@ export async function loadRepoLocalPolicy(repoRoot: string): Promise<RepoPolicy 
 
   if (parsed.default_remote !== undefined) {
     throw new ConfigError(`repo-local config '${configPath}' must not set default_remote`);
+  }
+
+  if (basePolicy) {
+    if (parsed.allowed_branch_patterns !== undefined) {
+      throw new ConfigError(
+        `repo-local config '${configPath}' must not set allowed_branch_patterns when overriding a globally allowlisted repository`,
+      );
+    }
+
+    return {
+      ...basePolicy,
+      featureBranchPattern: resolveFeatureBranchPattern(parsed.feature_branch_pattern) ?? basePolicy.featureBranchPattern,
+      gitWorktreeBasePath:
+        (await resolveGitWorktreeBasePath(parsed.git_worktree_base_path, { repoRoot: canonicalRepoRoot })) ??
+        basePolicy.gitWorktreeBasePath,
+      allowDraftPrs: parsed.allow_draft_prs ?? basePolicy.allowDraftPrs,
+      branchingPolicies: parsed.branching_policies ?? basePolicy.branchingPolicies,
+      policySource: "repo_local",
+      repoLocalConfigPath: configPath,
+      repoLocalConfigRelativePath: REPO_LOCAL_CONFIG_FILENAME,
+    };
+  }
+
+  if (parsed.allowed_branch_patterns === undefined) {
+    throw new ConfigError(
+      `repo-local config '${configPath}' must set allowed_branch_patterns unless overriding a globally allowlisted repository`,
+    );
   }
 
   return {

--- a/tests/repoAuth.test.ts
+++ b/tests/repoAuth.test.ts
@@ -88,7 +88,7 @@ describe("resolveAllowedRepo", () => {
     expect(resolvedRepo.allowedBranchPatterns.map((pattern) => pattern.source)).toEqual(["^codex\\/.+$"]);
   });
 
-  it("gives repo-local policy precedence over global config for the same repository", async () => {
+  it("applies whitelisted repo-local overrides on top of global config for the same repository", async () => {
     const { repoDir } = await createTempGitRepo();
     tempPaths.push(repoDir);
     const canonicalRepoDir = await fs.realpath(repoDir);
@@ -96,9 +96,11 @@ describe("resolveAllowedRepo", () => {
     await fs.writeFile(
       path.join(repoDir, ".git-unleash.yaml"),
       [
-        "allowed_branch_patterns:",
-        '  - "^user/.+$"',
         'feature_branch_pattern: "user/<feature-name>"',
+        "git_worktree_base_path: .worktrees",
+        "allow_draft_prs: false",
+        "branching_policies:",
+        "  - worktree",
       ].join("\n"),
       "utf8",
     );
@@ -112,7 +114,10 @@ describe("resolveAllowedRepo", () => {
             worktreePath: canonicalRepoDir,
             allowedBranchPatterns: [/^main$/],
             featureBranchPattern: "main",
+            gitWorktreeBasePath: "/tmp/global-worktrees",
+            defaultRemote: "origin",
             allowDraftPrs: true,
+            branchingPolicies: ["feature_branch"],
             policySource: "global",
           },
         ],
@@ -122,7 +127,11 @@ describe("resolveAllowedRepo", () => {
 
     expect(resolvedRepo.policySource).toBe("repo_local");
     expect(resolvedRepo.featureBranchPattern).toBe("user/<feature-name>");
-    expect(resolvedRepo.allowedBranchPatterns.map((pattern) => pattern.source)).toEqual(["^user\\/.+$"]);
+    expect(resolvedRepo.gitWorktreeBasePath).toBe(path.join(canonicalRepoDir, ".worktrees"));
+    expect(resolvedRepo.defaultRemote).toBe("origin");
+    expect(resolvedRepo.allowDraftPrs).toBe(false);
+    expect(resolvedRepo.branchingPolicies).toEqual(["worktree"]);
+    expect(resolvedRepo.allowedBranchPatterns.map((pattern) => pattern.source)).toEqual(["^main$"]);
   });
 
   it("rejects repo-local config that sets default_remote", async () => {
@@ -141,6 +150,60 @@ describe("resolveAllowedRepo", () => {
 
     await expect(resolveAllowedRepo({ repositories: [] }, repoDir)).rejects.toEqual(
       new ConfigError(`repo-local config '${path.join(await fs.realpath(repoDir), ".git-unleash.yaml")}' must not set default_remote`),
+    );
+  });
+
+  it("rejects repo-local config without allowed_branch_patterns when the repository is not globally allowlisted", async () => {
+    const { repoDir } = await createTempGitRepo();
+    tempPaths.push(repoDir);
+
+    await fs.writeFile(
+      path.join(repoDir, ".git-unleash.yaml"),
+      ['feature_branch_pattern: "user/<feature-name>"'].join("\n"),
+      "utf8",
+    );
+
+    await expect(resolveAllowedRepo({ repositories: [] }, repoDir)).rejects.toEqual(
+      new ConfigError(
+        `repo-local config '${path.join(await fs.realpath(repoDir), ".git-unleash.yaml")}' must set allowed_branch_patterns unless overriding a globally allowlisted repository`,
+      ),
+    );
+  });
+
+  it("rejects repo-local config that sets allowed_branch_patterns when overriding a globally allowlisted repository", async () => {
+    const { repoDir } = await createTempGitRepo();
+    tempPaths.push(repoDir);
+    const canonicalRepoDir = await fs.realpath(repoDir);
+
+    await fs.writeFile(
+      path.join(repoDir, ".git-unleash.yaml"),
+      [
+        "allowed_branch_patterns:",
+        '  - "^user/.+$"',
+      ].join("\n"),
+      "utf8",
+    );
+
+    await expect(
+      resolveAllowedRepo(
+        {
+          repositories: [
+            {
+              path: repoDir,
+              canonicalPath: canonicalRepoDir,
+              worktreePath: canonicalRepoDir,
+              allowedBranchPatterns: [/^main$/],
+              allowDraftPrs: true,
+              policySource: "global",
+            },
+          ],
+        },
+        repoDir,
+      ),
+    ).rejects.toEqual(
+      new ConfigError(
+        `repo-local config '${path.join(canonicalRepoDir, ".git-unleash.yaml")}' must not set allowed_branch_patterns when overriding a globally allowlisted repository`,
+      ),
     );
   });
 


### PR DESCRIPTION
## Why

Some repositories only need repo-specific workflow hints such as `feature_branch_pattern` or `git_worktree_base_path`, but the current repo-local policy model forces `.git-unleash.yaml` to replace the global policy entirely. That makes simple per-repo customization heavier than it needs to be and blurs the security boundary around branch authorization.

This change keeps zero-setup repo-local policy working as before, while letting globally allowlisted repositories use `.git-unleash.yaml` as a narrow override layer for non-authorization fields.

## Impact

Globally allowlisted repositories can now override `feature_branch_pattern`, `git_worktree_base_path`, `allow_draft_prs`, and `branching_policies` from `.git-unleash.yaml` without redefining branch authorization. Repo-local policy still cannot set `default_remote`, and in overlay mode it also cannot set `allowed_branch_patterns`, which keeps branch permissions anchored in the global config. Zero-setup repo-local policy still requires `allowed_branch_patterns`.

Closes #41