### PR TITLE
Keep repo-local policy authoritative with opted-in global repo overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,17 +123,56 @@ feature_branch_pattern: "<user>/<feature-name>"
 git_worktree_base_path: .worktrees
 branching_policies:
   - worktree
+allow_global_repo_overrides:
+  - feature_branch_pattern
 ```
 
 Repo-local policy rules:
 
-- `.git-unleash.yaml` takes precedence over global config for the same repository
+- `.git-unleash.yaml` is authoritative for the repository when it exists
 - global config still works as a fallback when a repository does not define `.git-unleash.yaml`
+- `allowed_branch_patterns` always come from `.git-unleash.yaml`; top-level `defaults` from the global config never override repo-local policy
+- `default_remote` is never inherited from the global config when `.git-unleash.yaml` is present
+- `allow_global_repo_overrides` is optional and may list `feature_branch_pattern`, `git_worktree_base_path`, `allow_draft_prs`, and `branching_policies`
+- `allow_global_repo_overrides` only applies values from the matching repository entry in the global config; inherited top-level `defaults` never override `.git-unleash.yaml`
 - for repo-local policy, `git_worktree_base_path` may be relative to the repository root
 - repo-local policy must not set `default_remote`
 - runtime tools fetch the trusted base branch of the current repository instance, compare the repo-local policy in base, index, and working tree, and fail closed on any divergence
 - in a fork, the fork's own base branch is authoritative for repo-local policy
 - this prevents locally widened repo-local policy from being used for MCP operations
+
+Example opt-in override from a matching global repository entry:
+
+Global config:
+
+```yaml
+defaults:
+  feature_branch_pattern: "defaults-do-not-win/<feature-name>"
+
+repositories:
+  - path: /Users/alice/project
+    feature_branch_pattern: "bob/<feature-name>"
+```
+
+Repo-local `.git-unleash.yaml`:
+
+```yaml
+allowed_branch_patterns:
+  - "^[a-zA-Z0-9.]/.*$"
+feature_branch_pattern: "<user>/<feature-name>"
+allow_global_repo_overrides:
+  - feature_branch_pattern
+```
+
+Effective policy:
+
+```yaml
+allowed_branch_patterns:
+  - "^[a-zA-Z0-9.]/.*$"
+feature_branch_pattern: "bob/<feature-name>"
+```
+
+In that example, the matching repository entry overrides `feature_branch_pattern`, while the global `defaults.feature_branch_pattern` is ignored because repo-local policy did not opt into defaults and defaults never override `.git-unleash.yaml`.
 
 ## Workflow Summary
 

--- a/src/auth/repoAuth.ts
+++ b/src/auth/repoAuth.ts
@@ -13,7 +13,8 @@ export async function resolveAllowedRepo(config: Config, repoPath: string): Prom
     throw new RepoNotAllowedError(absolutePath);
   }
 
-  const repoLocalPolicy = await loadRepoLocalPolicy(resolvedRepo.topLevel);
+  const repo = await findMatchingRepo(config, resolvedRepo.commonDir);
+  const repoLocalPolicy = await loadRepoLocalPolicy(resolvedRepo.topLevel, repo);
   if (repoLocalPolicy) {
     return {
       ...repoLocalPolicy,
@@ -21,7 +22,6 @@ export async function resolveAllowedRepo(config: Config, repoPath: string): Prom
     };
   }
 
-  const repo = await findMatchingRepo(config, resolvedRepo.commonDir);
   if (repo) {
     return {
       ...repo,

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,12 +6,25 @@ import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
 import { z } from "zod";
 
 import { ConfigError } from "./errors.js";
-import type { BranchingPolicy, Config, RepoPolicy } from "./types/config.js";
+import type {
+  BranchingPolicy,
+  Config,
+  GlobalRepoOverrideField,
+  RepoPolicy,
+  RepoPolicyGlobalRepoOverrides,
+} from "./types/config.js";
 
 export const REPO_LOCAL_CONFIG_FILENAME = ".git-unleash.yaml";
 
 const branchingPolicySchema = z.enum(["worktree", "feature_branch", "current_branch"]);
 const branchingPoliciesSchema = z.array(branchingPolicySchema).nonempty();
+const globalRepoOverrideFieldSchema = z.enum([
+  "feature_branch_pattern",
+  "git_worktree_base_path",
+  "allow_draft_prs",
+  "branching_policies",
+]);
+const globalRepoOverrideFieldsSchema = z.array(globalRepoOverrideFieldSchema).nonempty();
 
 const policyDefaultsSchema = z.object({
   allowed_branch_patterns: z.array(z.string().min(1)).nonempty().optional(),
@@ -33,6 +46,7 @@ const repoLocalPolicySchema = z.object({
   default_remote: z.string().min(1).optional(),
   allow_draft_prs: z.boolean().optional(),
   branching_policies: branchingPoliciesSchema.optional(),
+  allow_global_repo_overrides: globalRepoOverrideFieldsSchema.optional(),
 });
 
 const configSchema = z.object({
@@ -71,7 +85,10 @@ export async function loadOptionalConfig(configPath: string): Promise<Config | u
   }
 }
 
-export async function loadRepoLocalPolicy(repoRoot: string): Promise<RepoPolicy | undefined> {
+export async function loadRepoLocalPolicy(
+  repoRoot: string,
+  globalRepoPolicy?: RepoPolicy,
+): Promise<RepoPolicy | undefined> {
   const canonicalRepoRoot = await fs.realpath(repoRoot);
   const configPath = path.join(canonicalRepoRoot, REPO_LOCAL_CONFIG_FILENAME);
 
@@ -103,7 +120,7 @@ export async function loadRepoLocalPolicy(repoRoot: string): Promise<RepoPolicy 
     throw new ConfigError(`repo-local config '${configPath}' must not set default_remote`);
   }
 
-  return {
+  const repoLocalPolicy: RepoPolicy = {
     path: canonicalRepoRoot,
     canonicalPath: canonicalRepoRoot,
     worktreePath: canonicalRepoRoot,
@@ -116,6 +133,16 @@ export async function loadRepoLocalPolicy(repoRoot: string): Promise<RepoPolicy 
     repoLocalConfigPath: configPath,
     repoLocalConfigRelativePath: REPO_LOCAL_CONFIG_FILENAME,
   };
+
+  if (!globalRepoPolicy || parsed.allow_global_repo_overrides === undefined) {
+    return repoLocalPolicy;
+  }
+
+  return applyAllowedGlobalRepoOverrides(
+    repoLocalPolicy,
+    globalRepoPolicy.globalRepoOverrides,
+    parsed.allow_global_repo_overrides,
+  );
 }
 
 export async function bootstrapConfig(configPath: string, input: BootstrapConfigInput): Promise<EditableConfig> {
@@ -194,9 +221,17 @@ async function normalizeConfig(config: EditableConfig): Promise<Config> {
       throw new ConfigError(`duplicate configured repository path '${canonicalPath}'`);
     }
 
-    const gitWorktreeBasePath = await resolveGitWorktreeBasePath(
-      repo.git_worktree_base_path ?? config.defaults?.git_worktree_base_path,
-    );
+    const explicitFeatureBranchPattern =
+      repo.feature_branch_pattern === undefined ? undefined : resolveFeatureBranchPattern(repo.feature_branch_pattern);
+    const defaultFeatureBranchPattern = resolveFeatureBranchPattern(config.defaults?.feature_branch_pattern);
+
+    const explicitGitWorktreeBasePath =
+      repo.git_worktree_base_path === undefined ? undefined : await resolveGitWorktreeBasePath(repo.git_worktree_base_path);
+    const defaultGitWorktreeBasePath =
+      config.defaults?.git_worktree_base_path === undefined
+        ? undefined
+        : await resolveGitWorktreeBasePath(config.defaults.git_worktree_base_path);
+    const gitWorktreeBasePath = explicitGitWorktreeBasePath ?? defaultGitWorktreeBasePath;
 
     const repoPatternSources = repo.allowed_branch_patterns ?? config.defaults?.allowed_branch_patterns ?? [];
     const globalPatternSources = config.always_allowed_branch_patterns ?? [];
@@ -215,14 +250,18 @@ async function normalizeConfig(config: EditableConfig): Promise<Config> {
       canonicalPath,
       worktreePath: canonicalPath,
       allowedBranchPatterns,
-      featureBranchPattern: resolveFeatureBranchPattern(
-        repo.feature_branch_pattern ?? config.defaults?.feature_branch_pattern,
-      ),
+      featureBranchPattern: explicitFeatureBranchPattern ?? defaultFeatureBranchPattern,
       gitWorktreeBasePath,
       defaultRemote: repo.default_remote ?? config.defaults?.default_remote,
       allowDraftPrs: repo.allow_draft_prs ?? config.defaults?.allow_draft_prs ?? true,
       branchingPolicies: resolveBranchingPolicies(repo.branching_policies, config.defaults?.branching_policies),
       policySource: "global",
+      globalRepoOverrides: buildGlobalRepoOverrides({
+        featureBranchPattern: explicitFeatureBranchPattern,
+        gitWorktreeBasePath: explicitGitWorktreeBasePath,
+        allowDraftPrs: repo.allow_draft_prs,
+        branchingPolicies: repo.branching_policies,
+      }),
     });
 
     seenPaths.add(canonicalPath);
@@ -286,6 +325,68 @@ function resolveBranchingPolicies(
   defaultPolicies: BranchingPolicy[] | undefined,
 ): BranchingPolicy[] | undefined {
   return repoPolicies ?? defaultPolicies;
+}
+
+function buildGlobalRepoOverrides(input: RepoPolicyGlobalRepoOverrides): RepoPolicyGlobalRepoOverrides | undefined {
+  const overrides: RepoPolicyGlobalRepoOverrides = {
+    ...(input.featureBranchPattern !== undefined ? { featureBranchPattern: input.featureBranchPattern } : {}),
+    ...(input.gitWorktreeBasePath !== undefined ? { gitWorktreeBasePath: input.gitWorktreeBasePath } : {}),
+    ...(input.allowDraftPrs !== undefined ? { allowDraftPrs: input.allowDraftPrs } : {}),
+    ...(input.branchingPolicies !== undefined ? { branchingPolicies: input.branchingPolicies } : {}),
+  };
+
+  return Object.keys(overrides).length > 0 ? overrides : undefined;
+}
+
+function applyAllowedGlobalRepoOverrides(
+  repoLocalPolicy: RepoPolicy,
+  globalRepoOverrides: RepoPolicyGlobalRepoOverrides | undefined,
+  allowedFields: GlobalRepoOverrideField[],
+): RepoPolicy {
+  if (!globalRepoOverrides) {
+    return repoLocalPolicy;
+  }
+
+  let nextPolicy = repoLocalPolicy;
+
+  for (const field of allowedFields) {
+    switch (field) {
+      case "feature_branch_pattern":
+        if (globalRepoOverrides.featureBranchPattern !== undefined) {
+          nextPolicy = {
+            ...nextPolicy,
+            featureBranchPattern: globalRepoOverrides.featureBranchPattern,
+          };
+        }
+        break;
+      case "git_worktree_base_path":
+        if (globalRepoOverrides.gitWorktreeBasePath !== undefined) {
+          nextPolicy = {
+            ...nextPolicy,
+            gitWorktreeBasePath: globalRepoOverrides.gitWorktreeBasePath,
+          };
+        }
+        break;
+      case "allow_draft_prs":
+        if (globalRepoOverrides.allowDraftPrs !== undefined) {
+          nextPolicy = {
+            ...nextPolicy,
+            allowDraftPrs: globalRepoOverrides.allowDraftPrs,
+          };
+        }
+        break;
+      case "branching_policies":
+        if (globalRepoOverrides.branchingPolicies !== undefined) {
+          nextPolicy = {
+            ...nextPolicy,
+            branchingPolicies: globalRepoOverrides.branchingPolicies,
+          };
+        }
+        break;
+    }
+  }
+
+  return nextPolicy;
 }
 
 function resolveFeatureBranchPattern(pattern: string | undefined): string | undefined {

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -1,5 +1,17 @@
 export type BranchingPolicy = "worktree" | "feature_branch" | "current_branch";
 export type RepoPolicySource = "global" | "repo_local";
+export type GlobalRepoOverrideField =
+  | "feature_branch_pattern"
+  | "git_worktree_base_path"
+  | "allow_draft_prs"
+  | "branching_policies";
+
+export type RepoPolicyGlobalRepoOverrides = {
+  featureBranchPattern?: string;
+  gitWorktreeBasePath?: string;
+  allowDraftPrs?: boolean;
+  branchingPolicies?: BranchingPolicy[];
+};
 
 export type RepoPolicy = {
   path: string;
@@ -14,6 +26,7 @@ export type RepoPolicy = {
   policySource: RepoPolicySource;
   repoLocalConfigPath?: string;
   repoLocalConfigRelativePath?: string;
+  globalRepoOverrides?: RepoPolicyGlobalRepoOverrides;
 };
 
 export type Config = {

--- a/tests/repoAuth.test.ts
+++ b/tests/repoAuth.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+import { loadConfig } from "../src/config.js";
 import { resolveAllowedRepo } from "../src/auth/repoAuth.js";
 import { ConfigError, RepoNotAllowedError } from "../src/errors.js";
 import { runCommand } from "../src/exec/run.js";
@@ -88,7 +89,7 @@ describe("resolveAllowedRepo", () => {
     expect(resolvedRepo.allowedBranchPatterns.map((pattern) => pattern.source)).toEqual(["^codex\\/.+$"]);
   });
 
-  it("gives repo-local policy precedence over global config for the same repository", async () => {
+  it("allows matching global repo entries to override opted-in repo-local fields", async () => {
     const { repoDir } = await createTempGitRepo();
     tempPaths.push(repoDir);
     const canonicalRepoDir = await fs.realpath(repoDir);
@@ -97,8 +98,17 @@ describe("resolveAllowedRepo", () => {
       path.join(repoDir, ".git-unleash.yaml"),
       [
         "allowed_branch_patterns:",
-        '  - "^user/.+$"',
-        'feature_branch_pattern: "user/<feature-name>"',
+        '  - "^owner/.+$"',
+        'feature_branch_pattern: "owner/<feature-name>"',
+        "git_worktree_base_path: .worktrees",
+        "allow_draft_prs: true",
+        "branching_policies:",
+        "  - worktree",
+        "allow_global_repo_overrides:",
+        "  - feature_branch_pattern",
+        "  - git_worktree_base_path",
+        "  - allow_draft_prs",
+        "  - branching_policies",
       ].join("\n"),
       "utf8",
     );
@@ -111,9 +121,18 @@ describe("resolveAllowedRepo", () => {
             canonicalPath: canonicalRepoDir,
             worktreePath: canonicalRepoDir,
             allowedBranchPatterns: [/^main$/],
-            featureBranchPattern: "main",
-            allowDraftPrs: true,
+            featureBranchPattern: "bob/<feature-name>",
+            gitWorktreeBasePath: "/tmp/global-worktrees",
+            defaultRemote: "origin",
+            allowDraftPrs: false,
+            branchingPolicies: ["current_branch"],
             policySource: "global",
+            globalRepoOverrides: {
+              featureBranchPattern: "bob/<feature-name>",
+              gitWorktreeBasePath: "/tmp/global-worktrees",
+              allowDraftPrs: false,
+              branchingPolicies: ["current_branch"],
+            },
           },
         ],
       },
@@ -121,8 +140,120 @@ describe("resolveAllowedRepo", () => {
     );
 
     expect(resolvedRepo.policySource).toBe("repo_local");
-    expect(resolvedRepo.featureBranchPattern).toBe("user/<feature-name>");
-    expect(resolvedRepo.allowedBranchPatterns.map((pattern) => pattern.source)).toEqual(["^user\\/.+$"]);
+    expect(resolvedRepo.featureBranchPattern).toBe("bob/<feature-name>");
+    expect(resolvedRepo.gitWorktreeBasePath).toBe("/tmp/global-worktrees");
+    expect(resolvedRepo.allowDraftPrs).toBe(false);
+    expect(resolvedRepo.branchingPolicies).toEqual(["current_branch"]);
+    expect(resolvedRepo.defaultRemote).toBeUndefined();
+    expect(resolvedRepo.allowedBranchPatterns.map((pattern) => pattern.source)).toEqual(["^owner\\/.+$"]);
+  });
+
+  it("does not apply matching global repo entry values without repo-local opt-in", async () => {
+    const { repoDir } = await createTempGitRepo();
+    tempPaths.push(repoDir);
+    const canonicalRepoDir = await fs.realpath(repoDir);
+
+    await fs.writeFile(
+      path.join(repoDir, ".git-unleash.yaml"),
+      [
+        "allowed_branch_patterns:",
+        '  - "^owner/.+$"',
+        'feature_branch_pattern: "owner/<feature-name>"',
+        "git_worktree_base_path: .worktrees",
+        "allow_draft_prs: true",
+        "branching_policies:",
+        "  - worktree",
+      ].join("\n"),
+      "utf8",
+    );
+
+    const resolvedRepo = await resolveAllowedRepo(
+      {
+        repositories: [
+          {
+            path: repoDir,
+            canonicalPath: canonicalRepoDir,
+            worktreePath: canonicalRepoDir,
+            allowedBranchPatterns: [/^main$/],
+            featureBranchPattern: "bob/<feature-name>",
+            gitWorktreeBasePath: "/tmp/global-worktrees",
+            defaultRemote: "origin",
+            allowDraftPrs: false,
+            branchingPolicies: ["current_branch"],
+            policySource: "global",
+            globalRepoOverrides: {
+              featureBranchPattern: "bob/<feature-name>",
+              gitWorktreeBasePath: "/tmp/global-worktrees",
+              allowDraftPrs: false,
+              branchingPolicies: ["current_branch"],
+            },
+          },
+        ],
+      },
+      repoDir,
+    );
+
+    expect(resolvedRepo.featureBranchPattern).toBe("owner/<feature-name>");
+    expect(resolvedRepo.gitWorktreeBasePath).toBe(path.join(canonicalRepoDir, ".worktrees"));
+    expect(resolvedRepo.allowDraftPrs).toBe(true);
+    expect(resolvedRepo.branchingPolicies).toEqual(["worktree"]);
+    expect(resolvedRepo.defaultRemote).toBeUndefined();
+    expect(resolvedRepo.allowedBranchPatterns.map((pattern) => pattern.source)).toEqual(["^owner\\/.+$"]);
+  });
+
+  it("does not let top-level defaults override repo-local policy", async () => {
+    const { repoDir } = await createTempGitRepo();
+    const configPath = path.join(os.tmpdir(), `git-mcp-config-${Date.now()}-repo-local-defaults.yaml`);
+    tempPaths.push(repoDir, configPath);
+    const canonicalRepoDir = await fs.realpath(repoDir);
+
+    await fs.writeFile(
+      path.join(repoDir, ".git-unleash.yaml"),
+      [
+        "allowed_branch_patterns:",
+        '  - "^owner/.+$"',
+        'feature_branch_pattern: "owner/<feature-name>"',
+        "git_worktree_base_path: .worktrees",
+        "allow_draft_prs: true",
+        "branching_policies:",
+        "  - worktree",
+        "allow_global_repo_overrides:",
+        "  - feature_branch_pattern",
+        "  - git_worktree_base_path",
+        "  - allow_draft_prs",
+        "  - branching_policies",
+      ].join("\n"),
+      "utf8",
+    );
+
+    await fs.writeFile(
+      configPath,
+      [
+        "defaults:",
+        "  allowed_branch_patterns:",
+        '    - "^main$"',
+        '  feature_branch_pattern: "bob/<feature-name>"',
+        "  git_worktree_base_path: /tmp/default-worktrees",
+        "  default_remote: origin",
+        "  allow_draft_prs: false",
+        "  branching_policies:",
+        "    - current_branch",
+        "repositories:",
+        `  - path: ${repoDir}`,
+      ].join("\n"),
+      "utf8",
+    );
+
+    const config = await loadConfig(configPath);
+    const resolvedRepo = await resolveAllowedRepo(config, repoDir);
+
+    expect(resolvedRepo.policySource).toBe("repo_local");
+    expect(resolvedRepo.featureBranchPattern).toBe("owner/<feature-name>");
+    expect(resolvedRepo.gitWorktreeBasePath).toBe(path.join(canonicalRepoDir, ".worktrees"));
+    expect(resolvedRepo.allowDraftPrs).toBe(true);
+    expect(resolvedRepo.branchingPolicies).toEqual(["worktree"]);
+    expect(resolvedRepo.defaultRemote).toBeUndefined();
+    expect(resolvedRepo.allowedBranchPatterns.map((pattern) => pattern.source)).toEqual(["^owner\\/.+$"]);
   });
 
   it("rejects repo-local config that sets default_remote", async () => {


### PR DESCRIPTION
## Why

Issue #41 clarified that `.git-unleash.yaml` should remain authoritative for a repository, while still being able to opt into selected overrides from the matching repository entry in the global config. The current implementation gave repo-local config full precedence and could not distinguish explicit per-repo config from inherited global `defaults`, which made that precedence model impossible to express safely.

This change keeps repo-local policy as the source of truth, adds an explicit `allow_global_repo_overrides` allowlist for non-authorization workflow fields, and carries explicit repository-entry metadata through normalization so inherited `defaults` can never override `.git-unleash.yaml`.

## Impact

Repositories with `.git-unleash.yaml` can now opt into global repository-entry overrides for `feature_branch_pattern`, `git_worktree_base_path`, `allow_draft_prs`, and `branching_policies` without giving up repo-local control of `allowed_branch_patterns`. Top-level global `defaults` still never override repo-local policy, and `default_remote` remains non-overridable when repo-local policy is present.

The behavior change is covered by repo-auth tests for opted-in overrides, no-opt-in behavior, and the invariant that global `defaults` cannot override `.git-unleash.yaml`. The README now documents the precedence model and the new field.

Closes #41