### PR TITLE
Add explicit MCP tool annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 # codex-git-unleash-mcp
 
-Local MCP server for a narrow, policy-constrained set of Git and GitHub operations that Codex can call without repeated sandbox approval prompts.
+Local MCP server for a narrow, policy-constrained set of Git and GitHub operations that Codex can call with fewer repeated shell and sandbox approval prompts.
 
 It exists to handle a small approved workflow through MCP tools: inspect repository state, stage and commit changes, fetch and push the current branch, create or switch local branches in a constrained way, and open draft pull requests.
 
 This is especially useful with OpenAI Codex sandbox, where protected-path behavior still applies to paths such as `.git`. In practice, shell Git operations that write repository metadata can still be blocked or require approval, while direct GitHub network mutations may still be allowed or approval-gated depending on runtime policy.
+
+The MCP tool metadata in this server is explicit about which tools are read-only, which ones are additive mutations, and which ones may replace existing local or remote state. That can help Codex make better approval decisions, but it does not bypass Codex approval policy or higher-level safety monitoring. Repository mutations may still prompt for approval or be cancelled by the client/runtime.
 
 See OpenAI Codex docs: [Protected paths in writable roots](https://developers.openai.com/codex/agent-approvals-security#protected-paths-in-writable-roots).
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,4 +1,5 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { ToolAnnotations } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
 
 import { bootstrapConfig, loadOptionalConfig, upsertRepoConfig } from "./config.js";
@@ -26,6 +27,24 @@ const configPolicyFields = {
   default_remote: z.string().min(1).optional(),
   allow_draft_prs: z.boolean().optional(),
   branching_policies: branchingPoliciesSchema.optional(),
+};
+
+const CLOSED_WORLD_READ_ONLY_TOOL: ToolAnnotations = {
+  readOnlyHint: true,
+  idempotentHint: true,
+  openWorldHint: false,
+};
+
+const CLOSED_WORLD_ADDITIVE_MUTATION_TOOL: ToolAnnotations = {
+  readOnlyHint: false,
+  destructiveHint: false,
+  openWorldHint: false,
+};
+
+const CLOSED_WORLD_POTENTIALLY_DESTRUCTIVE_MUTATION_TOOL: ToolAnnotations = {
+  readOnlyHint: false,
+  destructiveHint: true,
+  openWorldHint: false,
 };
 
 export function getRegisteredToolNames(): string[] {
@@ -69,6 +88,7 @@ export function createServer(configPath: string): McpServer {
       ...configPolicyFields,
       always_allowed_branch_patterns: z.array(z.string().min(1)).min(1).optional(),
     },
+    CLOSED_WORLD_ADDITIVE_MUTATION_TOOL,
     async (input) => {
       const nextConfig = await bootstrapConfig(configPath, input);
 
@@ -98,6 +118,7 @@ export function createServer(configPath: string): McpServer {
       repo_path: z.string().min(1),
       ...configPolicyFields,
     },
+    CLOSED_WORLD_POTENTIALLY_DESTRUCTIVE_MUTATION_TOOL,
     async (input) => {
       const result = await upsertRepoConfig(configPath, input);
 
@@ -127,6 +148,7 @@ export function createServer(configPath: string): McpServer {
     {
       repo_path: z.string().min(1),
     },
+    CLOSED_WORLD_READ_ONLY_TOOL,
     async ({ repo_path }) => {
       const repo = await resolveRuntimeRepo(configPath, repo_path, { requireTrustedRepoPolicy: false });
       const result = getGitRepoPolicy(repo);
@@ -148,6 +170,7 @@ export function createServer(configPath: string): McpServer {
     {
       repo_path: z.string().min(1),
     },
+    CLOSED_WORLD_READ_ONLY_TOOL,
     async ({ repo_path }) => {
       const repo = await resolveRuntimeRepo(configPath, repo_path, { requireTrustedRepoPolicy: false });
       const status = await getGitStatus(repo);
@@ -170,6 +193,7 @@ export function createServer(configPath: string): McpServer {
       repo_path: z.string().min(1),
       paths: z.array(z.string().min(1)).min(1),
     },
+    CLOSED_WORLD_ADDITIVE_MUTATION_TOOL,
     async ({ repo_path, paths }) => {
       const repo = await resolveRuntimeRepo(configPath, repo_path);
       await requireAllowedBranch(repo);
@@ -193,6 +217,7 @@ export function createServer(configPath: string): McpServer {
       repo_path: z.string().min(1),
       message: z.string(),
     },
+    CLOSED_WORLD_ADDITIVE_MUTATION_TOOL,
     async ({ repo_path, message }) => {
       const repo = await resolveRuntimeRepo(configPath, repo_path);
       await requireAllowedBranch(repo);
@@ -217,6 +242,7 @@ export function createServer(configPath: string): McpServer {
       new_branch: z.string(),
       branch: z.string().min(1).optional(),
     },
+    CLOSED_WORLD_POTENTIALLY_DESTRUCTIVE_MUTATION_TOOL,
     async ({ repo_path, new_branch, branch }) => {
       const repo = await resolveRuntimeRepo(configPath, repo_path);
       const result = await gitBranchCreateAndSwitch(repo, { newBranch: new_branch, branch });
@@ -239,6 +265,7 @@ export function createServer(configPath: string): McpServer {
       repo_path: z.string().min(1),
       branch: z.string(),
     },
+    CLOSED_WORLD_POTENTIALLY_DESTRUCTIVE_MUTATION_TOOL,
     async ({ repo_path, branch }) => {
       const repo = await resolveRuntimeRepo(configPath, repo_path);
       const result = await gitBranchSwitch(repo, branch);
@@ -261,6 +288,7 @@ export function createServer(configPath: string): McpServer {
       repo_path: z.string().min(1),
       branch: z.string().optional(),
     },
+    CLOSED_WORLD_POTENTIALLY_DESTRUCTIVE_MUTATION_TOOL,
     async ({ repo_path, branch }) => {
       const repo = await resolveRuntimeRepo(configPath, repo_path);
       const result = await gitFetch(repo, { branch });
@@ -285,6 +313,7 @@ export function createServer(configPath: string): McpServer {
       new_branch: z.string(),
       branch: z.string().min(1).optional(),
     },
+    CLOSED_WORLD_ADDITIVE_MUTATION_TOOL,
     async ({ repo_path, path, new_branch, branch }) => {
       const repo = await resolveRuntimeRepo(configPath, repo_path);
       const result = await gitWorktreeAdd(repo, { path, newBranch: new_branch, branch });
@@ -306,6 +335,7 @@ export function createServer(configPath: string): McpServer {
     {
       repo_path: z.string().min(1),
     },
+    CLOSED_WORLD_POTENTIALLY_DESTRUCTIVE_MUTATION_TOOL,
     async ({ repo_path }) => {
       const repo = await resolveRuntimeRepo(configPath, repo_path);
       const branch = await requireAllowedBranch(repo);
@@ -331,6 +361,7 @@ export function createServer(configPath: string): McpServer {
       body: z.string(),
       base: z.string().min(1).optional(),
     },
+    CLOSED_WORLD_ADDITIVE_MUTATION_TOOL,
     async ({ repo_path, title, body, base }) => {
       const repo = await resolveRuntimeRepo(configPath, repo_path);
       const branch = await requireAllowedBranch(repo);

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -5,7 +5,7 @@ import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { ConfigError } from "../src/errors.js";
-import { getRegisteredToolNames, loadRuntimeConfig } from "../src/server.js";
+import { createServer, getRegisteredToolNames, loadRuntimeConfig } from "../src/server.js";
 
 const tempPaths: string[] = [];
 
@@ -29,6 +29,81 @@ describe("getRegisteredToolNames", () => {
       "git_push",
       "gh_pr_create_draft",
     ]);
+  });
+});
+
+describe("createServer", () => {
+  it("registers explicit tool annotations that match the tool contracts", () => {
+    const server = createServer("/tmp/config.yaml") as unknown as {
+      _registeredTools: Record<string, { annotations?: Record<string, boolean> }>;
+    };
+
+    const annotationsByTool = Object.fromEntries(
+      Object.entries(server._registeredTools).map(([name, tool]) => [name, tool.annotations ?? {}]),
+    );
+
+    expect(annotationsByTool).toEqual({
+      config_bootstrap: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        openWorldHint: false,
+      },
+      config_upsert_repo: {
+        readOnlyHint: false,
+        destructiveHint: true,
+        openWorldHint: false,
+      },
+      git_repo_policy: {
+        readOnlyHint: true,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+      git_status: {
+        readOnlyHint: true,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+      git_add: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        openWorldHint: false,
+      },
+      git_commit: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        openWorldHint: false,
+      },
+      git_branch_create_and_switch: {
+        readOnlyHint: false,
+        destructiveHint: true,
+        openWorldHint: false,
+      },
+      git_branch_switch: {
+        readOnlyHint: false,
+        destructiveHint: true,
+        openWorldHint: false,
+      },
+      git_fetch: {
+        readOnlyHint: false,
+        destructiveHint: true,
+        openWorldHint: false,
+      },
+      git_worktree_add: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        openWorldHint: false,
+      },
+      git_push: {
+        readOnlyHint: false,
+        destructiveHint: true,
+        openWorldHint: false,
+      },
+      gh_pr_create_draft: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        openWorldHint: false,
+      },
+    });
   });
 });
 


### PR DESCRIPTION
## Why
The MCP SDK defaults leave tool annotation fields implicit, which can make constrained Git mutation tools look more destructive than this server actually allows. This change makes the server contract explicit so Codex can make better approval decisions while still enforcing its own safety model.

## Impact
Adds explicit annotations for every registered tool, covers the metadata with a server test, and clarifies in the README that MCP can reduce some prompts but does not bypass Codex approval or safety gates.

Potential downside: tools that can replace or switch existing state are still marked as potentially destructive, so this does not guarantee zero prompts.

## Validation
- `npm run typecheck`
- `npm test`

Closes #42