### PR TITLE
Simplify config precedence and workflow mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,23 +61,17 @@ defaults:
   feature_branch_pattern: "<user>/<feature-name>"
   git_worktree_base_path: /tmp/git-worktrees
   allow_draft_prs: true
-  branching_policies:
-    - worktree
-
-always_allowed_branch_patterns:
-  - "^<user>/.*$"
+  workflow_mode: worktree
 
 repositories:
   - path: ~/projects/codex-git-unleash-mcp
     default_remote: origin
   - path: ~/projects/another-repo
-    branching_policies:
-      - current_branch
-      - feature_branch
     allowed_branch_patterns:
       - "^feature/[a-z0-9._-]+$"
     feature_branch_pattern: "feature/<feature-name>"
     allow_draft_prs: false
+    workflow_mode: feature_branch
 ```
 
 Notes:
@@ -86,31 +80,35 @@ Notes:
 - `config_bootstrap` creates a minimal valid YAML config file and refuses to overwrite an existing file
 - `config_upsert_repo` adds or updates one repository entry in the YAML config and matches existing entries by canonical repository path
 - config changes are reloaded from disk on the next tool call, so a server restart is not required after `config_bootstrap` or `config_upsert_repo`
-- top-level `defaults` are optional and may define `allowed_branch_patterns`, `feature_branch_pattern`, `git_worktree_base_path`, `default_remote`, `allow_draft_prs`, and `branching_policies`
-- top-level `always_allowed_branch_patterns` are optional and are appended to every repository's effective branch policy
+- top-level `defaults` are optional and may define `allowed_branch_patterns`, `feature_branch_pattern`, `git_worktree_base_path`, `default_remote`, `allow_draft_prs`, and `workflow_mode`
 - repository values override top-level defaults field-by-field
-- `defaults.allowed_branch_patterns` are inherited or overridden, while `always_allowed_branch_patterns` are always added
 - `feature_branch_pattern` is an optional suggested naming template for new feature branches; it is advisory metadata and does not grant permission to use a branch name that fails `allowed_branch_patterns`
-- `allowed_branch_patterns`, `always_allowed_branch_patterns`, and `feature_branch_pattern` support a dedicated `<user>` placeholder, resolved from `USER`, then `USERNAME`, then the system account username; other environment-variable expansion is intentionally not supported
+- `allowed_branch_patterns` and `feature_branch_pattern` support a dedicated `<user>` placeholder, resolved from `USER`, then `USERNAME`, then the system account username; other environment-variable expansion is intentionally not supported
 - `git_worktree_base_path` is inherited or overridden per repository and, when configured, constrains `git_worktree_add.path` to stay under that base
 - for Codex workflows, prefer a repo-specific in-repository worktree base such as `.worktrees/` when you want linked worktrees to stay under the same trusted project root; add that directory to `.gitignore`
-- `branching_policies` is optional and enforced for branch-setup tools; supported values are `worktree`, `feature_branch`, and `current_branch`
+- `workflow_mode` is optional and enforced for branch-setup tools; supported values are `worktree`, `feature_branch`, and `current_branch`
 - `worktree` means the preferred setup flow is `git_worktree_add`
 - `feature_branch` means the preferred setup flow is `git_branch_create_and_switch`
 - `current_branch` means do not create a new worktree or feature branch; work directly on the current allowed branch
-- when `branching_policies` contains multiple values, any matching setup flow is allowed
 - branch patterns are full-match regexes against the current branch name
-- each repository must end up with at least one effective allowed branch pattern, either from the repo entry, inherited `defaults`, or `always_allowed_branch_patterns`
-- `git_repo_policy` returns the configured branch patterns and related repository defaults for an authorized repository, including `feature_branch_pattern`, `git_worktree_base_path`, `branching_policies`, the policy source, and the repo-local config path when applicable
+- each repository must end up with at least one effective allowed branch pattern, either from the repo entry or inherited `defaults`
+- `git_repo_policy` returns the configured branch patterns and related repository defaults for an authorized repository, including `feature_branch_pattern`, `git_worktree_base_path`, `workflow_mode`, the policy source, whether repo overrides were applied, and the repo-local config path when applicable
 - `git_add`, `git_commit`, `git_push`, and `gh_pr_create_draft` require the current branch to match one of the configured patterns
 - `git_fetch` only requires the repository to be authorized, fetches from the resolved remote, and uses an explicit branch when provided or the detected base branch otherwise
-- `git_worktree_add` requires an explicit absolute target path, validates the requested new branch name against `allowed_branch_patterns`, creates a linked worktree from an explicit or detected upstream base branch, and is only allowed when `branching_policies` is unset or includes `worktree`
+- `git_worktree_add` requires an explicit absolute target path, validates the requested new branch name against `allowed_branch_patterns`, creates a linked worktree from an explicit or detected upstream base branch, and is only allowed when `workflow_mode` is unset or `worktree`
 - when `git_worktree_base_path` is configured, `git_worktree_add.path` must resolve under that base path
 - `git_branch_create_and_switch` and `git_branch_switch` require a clean worktree
-- `git_branch_create_and_switch` also requires the requested new branch name to match `allowed_branch_patterns`, and is only allowed when `branching_policies` is unset or includes `feature_branch`
+- `git_branch_create_and_switch` also requires the requested new branch name to match `allowed_branch_patterns`, and is only allowed when `workflow_mode` is unset or `feature_branch`
 - remote resolution prefers configured `default_remote` when present and valid, then the current branch's remote, then `origin`
 - branch creation and PR base resolution prefer the remote HEAD branch and fall back to GitHub default-branch detection when needed
 - `git_status` only requires the repository to be authorized
+
+Policy precedence:
+
+- if `.git-unleash.yaml` exists, it is the base policy for that repository
+- if the global config has a matching repository entry, that repository entry overrides the repo-local base field-by-field
+- otherwise, top-level `defaults` are the base policy
+- if the global config has a matching repository entry, that repository entry overrides the defaults base field-by-field
 
 ### Repo-Local Policy
 
@@ -123,20 +121,14 @@ allowed_branch_patterns:
   - "^<user>/.*$"
 feature_branch_pattern: "<user>/<feature-name>"
 git_worktree_base_path: .worktrees
-branching_policies:
-  - worktree
-allow_global_repo_overrides:
-  - feature_branch_pattern
+workflow_mode: worktree
 ```
 
 Repo-local policy rules:
 
-- `.git-unleash.yaml` is authoritative for the repository when it exists
+- `.git-unleash.yaml` replaces top-level `defaults` when it exists
+- a matching repository entry in the global config may still override repo-local values field-by-field
 - global config still works as a fallback when a repository does not define `.git-unleash.yaml`
-- `allowed_branch_patterns` always come from `.git-unleash.yaml`; top-level `defaults` from the global config never override repo-local policy
-- `default_remote` is never inherited from the global config when `.git-unleash.yaml` is present
-- `allow_global_repo_overrides` is optional and may list `feature_branch_pattern`, `git_worktree_base_path`, `allow_draft_prs`, and `branching_policies`
-- `allow_global_repo_overrides` only applies values from the matching repository entry in the global config; inherited top-level `defaults` never override `.git-unleash.yaml`
 - for repo-local policy, `git_worktree_base_path` may be relative to the repository root
 - repo-local policy must not set `default_remote`
 - runtime tools fetch the trusted base branch of the current repository instance, compare the repo-local policy in base, index, and working tree, and fail closed on any divergence
@@ -162,8 +154,6 @@ Repo-local `.git-unleash.yaml`:
 allowed_branch_patterns:
   - "^[a-zA-Z0-9.]/.*$"
 feature_branch_pattern: "<user>/<feature-name>"
-allow_global_repo_overrides:
-  - feature_branch_pattern
 ```
 
 Effective policy:
@@ -174,7 +164,7 @@ allowed_branch_patterns:
 feature_branch_pattern: "bob/<feature-name>"
 ```
 
-In that example, the matching repository entry overrides `feature_branch_pattern`, while the global `defaults.feature_branch_pattern` is ignored because repo-local policy did not opt into defaults and defaults never override `.git-unleash.yaml`.
+In that example, the matching repository entry overrides `feature_branch_pattern`, while the global `defaults.feature_branch_pattern` is ignored because repo-local policy replaces `defaults` for that repository.
 
 ## Workflow Summary
 
@@ -301,15 +291,15 @@ If you want to branch from `main` but only allow mutations on personal feature b
 defaults:
   allowed_branch_patterns:
     - "^main$"
-
-always_allowed_branch_patterns:
-  - "^<user>/.*$"
+  feature_branch_pattern: "<user>/<feature-name>"
+  workflow_mode: worktree
 
 repositories:
   - path: ~/projects/codex-git-unleash-mcp
   - path: ~/projects/codex-git-unleash-mcp-enterprise
     allowed_branch_patterns:
       - "^feature/[a-z0-9._-]+$"
+    workflow_mode: feature_branch
 ```
 
 If you want some repositories to stay on their base branch instead of creating a worktree or feature branch:
@@ -317,20 +307,18 @@ If you want some repositories to stay on their base branch instead of creating a
 ```yaml
 repositories:
   - path: ~/projects/dm-cv-on-steroids
-    branching_policies:
-      - current_branch
+    workflow_mode: current_branch
     allowed_branch_patterns:
       - "^main$"
   - path: ~/dot.files
-    branching_policies:
-      - current_branch
+    workflow_mode: current_branch
     allowed_branch_patterns:
       - "^main$"
 ```
 
 If you want to bootstrap the config and then add this repository incrementally, a minimal progression is:
 
-1. Call `config_bootstrap` with defaults such as `feature_branch_pattern`, `always_allowed_branch_patterns`, or `branching_policies`.
-2. Call `config_upsert_repo` with `repo_path`, and optionally `git_worktree_base_path`, `default_remote`, `allowed_branch_patterns`, or `branching_policies`.
+1. Call `config_bootstrap` with defaults such as `feature_branch_pattern` or `workflow_mode`.
+2. Call `config_upsert_repo` with `repo_path`, and optionally `git_worktree_base_path`, `default_remote`, `allowed_branch_patterns`, or `workflow_mode`.
 3. Use the Git tools against that repository; they will reload the YAML on each call.
 ```

--- a/SPEC.md
+++ b/SPEC.md
@@ -152,7 +152,7 @@ Optional configuration that may be useful:
 - default remote name
 - whether draft PR creation is enabled
 - suggested feature branch naming pattern
-- branching workflow policies (`worktree`, `feature_branch`, or `current_branch`) enforced for branch-setup tools
+- a workflow mode (`worktree`, `feature_branch`, or `current_branch`) enforced for branch-setup tools
 
 The initial branch and PR behavior should prefer runtime inference with a narrow fallback order:
 
@@ -170,8 +170,7 @@ repositories:
       - "^user/.*$"
       - "^feature/[a-z0-9._-]+$"
     allow_draft_prs: true
-    branching_policies:
-      - worktree
+    workflow_mode: worktree
 ```
 
 ## Describe Support

--- a/src/auth/branchingPolicy.ts
+++ b/src/auth/branchingPolicy.ts
@@ -1,16 +1,16 @@
 import { BranchingPolicyViolationError } from "../errors.js";
-import type { BranchingPolicy, RepoPolicy } from "../types/config.js";
+import type { RepoPolicy, WorkflowMode } from "../types/config.js";
 
-export function requireBranchingPolicy(
+export function requireWorkflowMode(
   repo: RepoPolicy,
   toolName: string,
-  allowedPolicies: BranchingPolicy[],
+  allowedModes: WorkflowMode[],
 ): void {
-  if (!repo.branchingPolicies || repo.branchingPolicies.length === 0) {
+  if (!repo.workflowMode) {
     return;
   }
 
-  if (!repo.branchingPolicies.some((policy) => allowedPolicies.includes(policy))) {
-    throw new BranchingPolicyViolationError(toolName, repo.worktreePath, repo.branchingPolicies);
+  if (!allowedModes.includes(repo.workflowMode)) {
+    throw new BranchingPolicyViolationError(toolName, repo.worktreePath, repo.workflowMode);
   }
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,25 +6,11 @@ import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
 import { z } from "zod";
 
 import { ConfigError } from "./errors.js";
-import type {
-  BranchingPolicy,
-  Config,
-  GlobalRepoOverrideField,
-  RepoPolicy,
-  RepoPolicyGlobalRepoOverrides,
-} from "./types/config.js";
+import type { Config, RepoPolicy, RepoPolicyOverrides, WorkflowMode } from "./types/config.js";
 
 export const REPO_LOCAL_CONFIG_FILENAME = ".git-unleash.yaml";
 
-const branchingPolicySchema = z.enum(["worktree", "feature_branch", "current_branch"]);
-const branchingPoliciesSchema = z.array(branchingPolicySchema).nonempty();
-const globalRepoOverrideFieldSchema = z.enum([
-  "feature_branch_pattern",
-  "git_worktree_base_path",
-  "allow_draft_prs",
-  "branching_policies",
-]);
-const globalRepoOverrideFieldsSchema = z.array(globalRepoOverrideFieldSchema).nonempty();
+const workflowModeSchema = z.enum(["worktree", "feature_branch", "current_branch"]);
 
 const policyDefaultsSchema = z.object({
   allowed_branch_patterns: z.array(z.string().min(1)).nonempty().optional(),
@@ -32,7 +18,7 @@ const policyDefaultsSchema = z.object({
   git_worktree_base_path: z.string().min(1).optional(),
   default_remote: z.string().min(1).optional(),
   allow_draft_prs: z.boolean().optional(),
-  branching_policies: branchingPoliciesSchema.optional(),
+  workflow_mode: workflowModeSchema.optional(),
 });
 
 const repoPolicySchema = policyDefaultsSchema.extend({
@@ -45,13 +31,11 @@ const repoLocalPolicySchema = z.object({
   git_worktree_base_path: z.string().min(1).optional(),
   default_remote: z.string().min(1).optional(),
   allow_draft_prs: z.boolean().optional(),
-  branching_policies: branchingPoliciesSchema.optional(),
-  allow_global_repo_overrides: globalRepoOverrideFieldsSchema.optional(),
+  workflow_mode: workflowModeSchema.optional(),
 });
 
 const configSchema = z.object({
   defaults: policyDefaultsSchema.optional(),
-  always_allowed_branch_patterns: z.array(z.string().min(1)).nonempty().optional(),
   repositories: z.array(repoPolicySchema),
 });
 
@@ -59,9 +43,7 @@ export type EditablePolicyDefaults = z.infer<typeof policyDefaultsSchema>;
 export type EditableRepoPolicy = z.infer<typeof repoPolicySchema>;
 export type EditableConfig = z.infer<typeof configSchema>;
 
-export type BootstrapConfigInput = EditablePolicyDefaults & {
-  always_allowed_branch_patterns?: string[];
-};
+export type BootstrapConfigInput = EditablePolicyDefaults;
 
 export type UpsertRepoConfigInput = {
   repo_path: string;
@@ -128,21 +110,18 @@ export async function loadRepoLocalPolicy(
     featureBranchPattern: resolveFeatureBranchPattern(parsed.feature_branch_pattern),
     gitWorktreeBasePath: await resolveGitWorktreeBasePath(parsed.git_worktree_base_path, { repoRoot: canonicalRepoRoot }),
     allowDraftPrs: parsed.allow_draft_prs ?? true,
-    branchingPolicies: parsed.branching_policies,
+    workflowMode: parsed.workflow_mode,
     policySource: "repo_local",
     repoLocalConfigPath: configPath,
     repoLocalConfigRelativePath: REPO_LOCAL_CONFIG_FILENAME,
+    repoOverridesApplied: false,
   };
 
-  if (!globalRepoPolicy || parsed.allow_global_repo_overrides === undefined) {
+  if (!globalRepoPolicy?.repoOverrides) {
     return repoLocalPolicy;
   }
 
-  return applyAllowedGlobalRepoOverrides(
-    repoLocalPolicy,
-    globalRepoPolicy.globalRepoOverrides,
-    parsed.allow_global_repo_overrides,
-  );
+  return applyRepoOverrides(repoLocalPolicy, globalRepoPolicy.repoOverrides);
 }
 
 export async function bootstrapConfig(configPath: string, input: BootstrapConfigInput): Promise<EditableConfig> {
@@ -152,7 +131,6 @@ export async function bootstrapConfig(configPath: string, input: BootstrapConfig
 
   const config = sanitizeEditableConfig({
     defaults: toOptionalPolicyDefaults(input),
-    always_allowed_branch_patterns: input.always_allowed_branch_patterns,
     repositories: [],
   });
 
@@ -233,17 +211,25 @@ async function normalizeConfig(config: EditableConfig): Promise<Config> {
         : await resolveGitWorktreeBasePath(config.defaults.git_worktree_base_path);
     const gitWorktreeBasePath = explicitGitWorktreeBasePath ?? defaultGitWorktreeBasePath;
 
-    const repoPatternSources = repo.allowed_branch_patterns ?? config.defaults?.allowed_branch_patterns ?? [];
-    const globalPatternSources = config.always_allowed_branch_patterns ?? [];
-    const patternSources = [...repoPatternSources, ...globalPatternSources];
+    const patternSources = repo.allowed_branch_patterns ?? config.defaults?.allowed_branch_patterns ?? [];
 
     if (patternSources.length === 0) {
       throw new ConfigError(
-        `repository '${repo.path}' must define allowed_branch_patterns directly, inherit them from top-level defaults, or rely on always_allowed_branch_patterns`,
+        `repository '${repo.path}' must define allowed_branch_patterns directly or inherit them from top-level defaults`,
       );
     }
 
     const allowedBranchPatterns = compileBranchPatterns(patternSources, repo.path);
+    const workflowMode = repo.workflow_mode ?? config.defaults?.workflow_mode;
+    const repoOverrides = buildRepoOverrides({
+      allowedBranchPatterns:
+        repo.allowed_branch_patterns === undefined ? undefined : compileBranchPatterns(repo.allowed_branch_patterns, repo.path),
+      featureBranchPattern: explicitFeatureBranchPattern,
+      gitWorktreeBasePath: explicitGitWorktreeBasePath,
+      defaultRemote: repo.default_remote,
+      allowDraftPrs: repo.allow_draft_prs,
+      workflowMode: repo.workflow_mode,
+    });
 
     repositories.push({
       path: expandedPath,
@@ -254,14 +240,10 @@ async function normalizeConfig(config: EditableConfig): Promise<Config> {
       gitWorktreeBasePath,
       defaultRemote: repo.default_remote ?? config.defaults?.default_remote,
       allowDraftPrs: repo.allow_draft_prs ?? config.defaults?.allow_draft_prs ?? true,
-      branchingPolicies: resolveBranchingPolicies(repo.branching_policies, config.defaults?.branching_policies),
+      workflowMode,
       policySource: "global",
-      globalRepoOverrides: buildGlobalRepoOverrides({
-        featureBranchPattern: explicitFeatureBranchPattern,
-        gitWorktreeBasePath: explicitGitWorktreeBasePath,
-        allowDraftPrs: repo.allow_draft_prs,
-        branchingPolicies: repo.branching_policies,
-      }),
+      repoOverrides,
+      repoOverridesApplied: repoOverrides !== undefined,
     });
 
     seenPaths.add(canonicalPath);
@@ -291,7 +273,6 @@ async function writeConfig(configPath: string, config: EditableConfig): Promise<
 function sanitizeEditableConfig(input: Partial<EditableConfig>): EditableConfig {
   return {
     ...(input.defaults ? { defaults: sanitizePolicyDefaults(input.defaults) } : {}),
-    ...(input.always_allowed_branch_patterns ? { always_allowed_branch_patterns: input.always_allowed_branch_patterns } : {}),
     repositories: (input.repositories ?? []).map((repo) => sanitizeEditableRepo(repo)),
   };
 }
@@ -316,77 +297,39 @@ function toOptionalPolicyDefaults(input: Partial<EditablePolicyDefaults>): Edita
     ...(input.git_worktree_base_path ? { git_worktree_base_path: input.git_worktree_base_path } : {}),
     ...(input.default_remote ? { default_remote: input.default_remote } : {}),
     ...(input.allow_draft_prs !== undefined ? { allow_draft_prs: input.allow_draft_prs } : {}),
-    ...(input.branching_policies ? { branching_policies: input.branching_policies } : {}),
+    ...(input.workflow_mode ? { workflow_mode: input.workflow_mode } : {}),
   };
 }
 
-function resolveBranchingPolicies(
-  repoPolicies: BranchingPolicy[] | undefined,
-  defaultPolicies: BranchingPolicy[] | undefined,
-): BranchingPolicy[] | undefined {
-  return repoPolicies ?? defaultPolicies;
-}
-
-function buildGlobalRepoOverrides(input: RepoPolicyGlobalRepoOverrides): RepoPolicyGlobalRepoOverrides | undefined {
-  const overrides: RepoPolicyGlobalRepoOverrides = {
+function buildRepoOverrides(input: RepoPolicyOverrides): RepoPolicyOverrides | undefined {
+  const overrides: RepoPolicyOverrides = {
+    ...(input.allowedBranchPatterns !== undefined ? { allowedBranchPatterns: input.allowedBranchPatterns } : {}),
     ...(input.featureBranchPattern !== undefined ? { featureBranchPattern: input.featureBranchPattern } : {}),
     ...(input.gitWorktreeBasePath !== undefined ? { gitWorktreeBasePath: input.gitWorktreeBasePath } : {}),
+    ...(input.defaultRemote !== undefined ? { defaultRemote: input.defaultRemote } : {}),
     ...(input.allowDraftPrs !== undefined ? { allowDraftPrs: input.allowDraftPrs } : {}),
-    ...(input.branchingPolicies !== undefined ? { branchingPolicies: input.branchingPolicies } : {}),
+    ...(input.workflowMode !== undefined ? { workflowMode: input.workflowMode } : {}),
   };
 
   return Object.keys(overrides).length > 0 ? overrides : undefined;
 }
 
-function applyAllowedGlobalRepoOverrides(
+function applyRepoOverrides(
   repoLocalPolicy: RepoPolicy,
-  globalRepoOverrides: RepoPolicyGlobalRepoOverrides | undefined,
-  allowedFields: GlobalRepoOverrideField[],
+  repoOverrides: RepoPolicyOverrides,
 ): RepoPolicy {
-  if (!globalRepoOverrides) {
-    return repoLocalPolicy;
-  }
-
-  let nextPolicy = repoLocalPolicy;
-
-  for (const field of allowedFields) {
-    switch (field) {
-      case "feature_branch_pattern":
-        if (globalRepoOverrides.featureBranchPattern !== undefined) {
-          nextPolicy = {
-            ...nextPolicy,
-            featureBranchPattern: globalRepoOverrides.featureBranchPattern,
-          };
-        }
-        break;
-      case "git_worktree_base_path":
-        if (globalRepoOverrides.gitWorktreeBasePath !== undefined) {
-          nextPolicy = {
-            ...nextPolicy,
-            gitWorktreeBasePath: globalRepoOverrides.gitWorktreeBasePath,
-          };
-        }
-        break;
-      case "allow_draft_prs":
-        if (globalRepoOverrides.allowDraftPrs !== undefined) {
-          nextPolicy = {
-            ...nextPolicy,
-            allowDraftPrs: globalRepoOverrides.allowDraftPrs,
-          };
-        }
-        break;
-      case "branching_policies":
-        if (globalRepoOverrides.branchingPolicies !== undefined) {
-          nextPolicy = {
-            ...nextPolicy,
-            branchingPolicies: globalRepoOverrides.branchingPolicies,
-          };
-        }
-        break;
-    }
-  }
-
-  return nextPolicy;
+  return {
+    ...repoLocalPolicy,
+    ...(repoOverrides.allowedBranchPatterns !== undefined
+      ? { allowedBranchPatterns: repoOverrides.allowedBranchPatterns }
+      : {}),
+    ...(repoOverrides.featureBranchPattern !== undefined ? { featureBranchPattern: repoOverrides.featureBranchPattern } : {}),
+    ...(repoOverrides.gitWorktreeBasePath !== undefined ? { gitWorktreeBasePath: repoOverrides.gitWorktreeBasePath } : {}),
+    ...(repoOverrides.defaultRemote !== undefined ? { defaultRemote: repoOverrides.defaultRemote } : {}),
+    ...(repoOverrides.allowDraftPrs !== undefined ? { allowDraftPrs: repoOverrides.allowDraftPrs } : {}),
+    ...(repoOverrides.workflowMode !== undefined ? { workflowMode: repoOverrides.workflowMode } : {}),
+    repoOverridesApplied: true,
+  };
 }
 
 function resolveFeatureBranchPattern(pattern: string | undefined): string | undefined {

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -38,9 +38,9 @@ export class BranchNameNotAllowedError extends Error {
 }
 
 export class BranchingPolicyViolationError extends Error {
-  constructor(toolName: string, repoPath: string, actualPolicies: string[]) {
+  constructor(toolName: string, repoPath: string, actualMode: string) {
     super(
-      `tool '${toolName}' is not allowed for repository '${repoPath}' under branching_policies [${actualPolicies.join(", ")}]; call 'git_repo_policy' and use one of the configured setup flows`,
+      `tool '${toolName}' is not allowed for repository '${repoPath}' under workflow_mode '${actualMode}'; call 'git_repo_policy' and use the configured setup flow`,
     );
     this.name = "BranchingPolicyViolationError";
   }

--- a/src/server.ts
+++ b/src/server.ts
@@ -18,7 +18,7 @@ import { getGitRepoPolicy } from "./tools/gitRepoPolicy.js";
 import { getGitStatus } from "./tools/gitStatus.js";
 import { gitWorktreeAdd } from "./tools/gitWorktreeAdd.js";
 
-const branchingPoliciesSchema = z.array(z.enum(["worktree", "feature_branch", "current_branch"])).min(1);
+const workflowModeSchema = z.enum(["worktree", "feature_branch", "current_branch"]);
 
 const configPolicyFields = {
   allowed_branch_patterns: z.array(z.string().min(1)).min(1).optional(),
@@ -26,7 +26,7 @@ const configPolicyFields = {
   git_worktree_base_path: z.string().min(1).optional(),
   default_remote: z.string().min(1).optional(),
   allow_draft_prs: z.boolean().optional(),
-  branching_policies: branchingPoliciesSchema.optional(),
+  workflow_mode: workflowModeSchema.optional(),
 };
 
 const CLOSED_WORLD_READ_ONLY_TOOL: ToolAnnotations = {
@@ -84,10 +84,7 @@ export function createServer(configPath: string): McpServer {
   server.tool(
     "config_bootstrap",
     "Create the initial MCP config file when it does not yet exist. This tool writes a minimal valid YAML config and does not apply changes to the current server process; restart the MCP server after use.",
-    {
-      ...configPolicyFields,
-      always_allowed_branch_patterns: z.array(z.string().min(1)).min(1).optional(),
-    },
+    configPolicyFields,
     CLOSED_WORLD_ADDITIVE_MUTATION_TOOL,
     async (input) => {
       const nextConfig = await bootstrapConfig(configPath, input);

--- a/src/tools/gitBranchCreateAndSwitch.ts
+++ b/src/tools/gitBranchCreateAndSwitch.ts
@@ -1,5 +1,5 @@
 import { requireAllowedBranchName } from "../auth/branchAuth.js";
-import { requireBranchingPolicy } from "../auth/branchingPolicy.js";
+import { requireWorkflowMode } from "../auth/branchingPolicy.js";
 import { BranchAlreadyExistsError, DirtyWorktreeError, EmptyBranchNameError } from "../errors.js";
 import { branchExists, createBranch, fetchBranch, switchBranch } from "../exec/git.js";
 import type { RepoPolicy } from "../types/config.js";
@@ -16,7 +16,7 @@ export async function gitBranchCreateAndSwitch(
   repo: RepoPolicy,
   input: { newBranch: string; branch?: string },
 ): Promise<GitBranchCreateAndSwitchResult> {
-  requireBranchingPolicy(repo, "git_branch_create_and_switch", ["feature_branch"]);
+  requireWorkflowMode(repo, "git_branch_create_and_switch", ["feature_branch"]);
   const normalizedBranch = input.newBranch.trim();
   if (!normalizedBranch) {
     throw new EmptyBranchNameError();

--- a/src/tools/gitRepoPolicy.ts
+++ b/src/tools/gitRepoPolicy.ts
@@ -8,9 +8,10 @@ export type GitRepoPolicyResult = {
   gitWorktreeBasePath?: string;
   defaultRemote?: string;
   allowDraftPrs: boolean;
-  branchingPolicies?: string[];
+  workflowMode?: string;
   policySource: string;
   repoLocalConfigPath?: string;
+  repoOverridesApplied: boolean;
 };
 
 export function getGitRepoPolicy(repo: RepoPolicy): GitRepoPolicyResult {
@@ -22,8 +23,9 @@ export function getGitRepoPolicy(repo: RepoPolicy): GitRepoPolicyResult {
     gitWorktreeBasePath: repo.gitWorktreeBasePath,
     defaultRemote: repo.defaultRemote,
     allowDraftPrs: repo.allowDraftPrs,
-    branchingPolicies: repo.branchingPolicies,
+    workflowMode: repo.workflowMode,
     policySource: repo.policySource,
     repoLocalConfigPath: repo.repoLocalConfigPath,
+    repoOverridesApplied: repo.repoOverridesApplied ?? false,
   };
 }

--- a/src/tools/gitWorktreeAdd.ts
+++ b/src/tools/gitWorktreeAdd.ts
@@ -1,5 +1,5 @@
 import { requireAllowedBranchName } from "../auth/branchAuth.js";
-import { requireBranchingPolicy } from "../auth/branchingPolicy.js";
+import { requireWorkflowMode } from "../auth/branchingPolicy.js";
 import { validateWorktreePathAgainstBasePath } from "../auth/pathValidation.js";
 import { BranchAlreadyExistsError, EmptyBranchNameError } from "../errors.js";
 import { addWorktree, branchExists, fetchBranch } from "../exec/git.js";
@@ -17,7 +17,7 @@ export async function gitWorktreeAdd(
   repo: RepoPolicy,
   input: { path: string; newBranch: string; branch?: string },
 ): Promise<GitWorktreeAddResult> {
-  requireBranchingPolicy(repo, "git_worktree_add", ["worktree"]);
+  requireWorkflowMode(repo, "git_worktree_add", ["worktree"]);
   const normalizedBranch = input.newBranch.trim();
   if (!normalizedBranch) {
     throw new EmptyBranchNameError();

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -1,16 +1,13 @@
-export type BranchingPolicy = "worktree" | "feature_branch" | "current_branch";
+export type WorkflowMode = "worktree" | "feature_branch" | "current_branch";
 export type RepoPolicySource = "global" | "repo_local";
-export type GlobalRepoOverrideField =
-  | "feature_branch_pattern"
-  | "git_worktree_base_path"
-  | "allow_draft_prs"
-  | "branching_policies";
 
-export type RepoPolicyGlobalRepoOverrides = {
+export type RepoPolicyOverrides = {
+  allowedBranchPatterns?: RegExp[];
   featureBranchPattern?: string;
   gitWorktreeBasePath?: string;
+  defaultRemote?: string;
   allowDraftPrs?: boolean;
-  branchingPolicies?: BranchingPolicy[];
+  workflowMode?: WorkflowMode;
 };
 
 export type RepoPolicy = {
@@ -22,11 +19,12 @@ export type RepoPolicy = {
   gitWorktreeBasePath?: string;
   defaultRemote?: string;
   allowDraftPrs: boolean;
-  branchingPolicies?: BranchingPolicy[];
+  workflowMode?: WorkflowMode;
   policySource: RepoPolicySource;
   repoLocalConfigPath?: string;
   repoLocalConfigRelativePath?: string;
-  globalRepoOverrides?: RepoPolicyGlobalRepoOverrides;
+  repoOverrides?: RepoPolicyOverrides;
+  repoOverridesApplied?: boolean;
 };
 
 export type Config = {

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -36,7 +36,7 @@ describe("loadConfig", () => {
      expect(config.repositories[0]?.gitWorktreeBasePath).toBeUndefined();
      expect(config.repositories[0]?.allowDraftPrs).toBe(true);
      expect(config.repositories[0]?.featureBranchPattern).toBeUndefined();
-     expect(config.repositories[0]?.branchingPolicies).toBeUndefined();
+     expect(config.repositories[0]?.workflowMode).toBeUndefined();
     expect(config.repositories[0]?.allowedBranchPatterns.map((pattern) => pattern.source)).toEqual(["^feature\\/.+$"]);
   });
 
@@ -55,8 +55,7 @@ describe("loadConfig", () => {
         "  git_worktree_base_path: ~/git-worktrees",
         "  default_remote: upstream",
         "  allow_draft_prs: false",
-        "  branching_policies:",
-        "    - worktree",
+        "  workflow_mode: worktree",
         "repositories:",
         `  - path: ${repoDir}`,
       ].join("\n"),
@@ -71,7 +70,7 @@ describe("loadConfig", () => {
      expect(config.repositories[0]?.gitWorktreeBasePath).toBe(expectedBasePath);
      expect(config.repositories[0]?.defaultRemote).toBe("upstream");
     expect(config.repositories[0]?.allowDraftPrs).toBe(false);
-    expect(config.repositories[0]?.branchingPolicies).toEqual(["worktree"]);
+    expect(config.repositories[0]?.workflowMode).toBe("worktree");
   });
 
   it("resolves <user> in inherited feature branch patterns from USER", async () => {
@@ -180,29 +179,6 @@ describe("loadConfig", () => {
     expect(config.repositories[0]?.featureBranchPattern).toBe("system-user/<feature-name>");
   });
 
-  it("resolves <user> in always-allowed branch patterns", async () => {
-    const repoDir = await fs.mkdtemp(path.join(os.tmpdir(), "git-mcp-global-user-pattern-repo-"));
-    const configPath = path.join(os.tmpdir(), `git-mcp-config-${Date.now()}-global-user-pattern.yaml`);
-    tempPaths.push(repoDir, configPath);
-    vi.stubEnv("USER", "codex");
-    vi.stubEnv("USERNAME", "");
-
-    await fs.writeFile(
-      configPath,
-      [
-        'always_allowed_branch_patterns:',
-        '  - "^<user>/.+$"',
-        "repositories:",
-        `  - path: ${repoDir}`,
-      ].join("\n"),
-      "utf8",
-    );
-
-    const config = await loadConfig(configPath);
-
-    expect(config.repositories[0]?.allowedBranchPatterns.map((pattern) => pattern.source)).toEqual(["^codex\\/.+$"]);
-  });
-
   it("rejects <user> config values when no runtime username can be determined", async () => {
     const repoDir = await fs.mkdtemp(path.join(os.tmpdir(), "git-mcp-missing-user-pattern-repo-"));
     const configPath = path.join(os.tmpdir(), `git-mcp-config-${Date.now()}-missing-user-pattern.yaml`);
@@ -228,32 +204,6 @@ describe("loadConfig", () => {
     await expect(loadConfig(configPath)).rejects.toThrow("config uses '<user>' but no runtime username could be determined");
   });
 
-  it("appends always-allowed branch patterns to repository policy", async () => {
-    const repoDir = await fs.mkdtemp(path.join(os.tmpdir(), "git-mcp-global-patterns-repo-"));
-    const configPath = path.join(os.tmpdir(), `git-mcp-config-${Date.now()}-global-patterns.yaml`);
-    tempPaths.push(repoDir, configPath);
-
-    await fs.writeFile(
-      configPath,
-      [
-        'always_allowed_branch_patterns:',
-        '  - "^user/.+$"',
-        "repositories:",
-        `  - path: ${repoDir}`,
-        "    allowed_branch_patterns:",
-        '      - "^main$"',
-      ].join("\n"),
-      "utf8",
-    );
-
-    const config = await loadConfig(configPath);
-
-    expect(config.repositories[0]?.allowedBranchPatterns.map((pattern) => pattern.source)).toEqual([
-      "^main$",
-      "^user\\/.+$",
-    ]);
-  });
-
   it("lets repositories override top-level defaults", async () => {
     const repoDir = await fs.mkdtemp(path.join(os.tmpdir(), "git-mcp-override-repo-"));
     const configPath = path.join(os.tmpdir(), `git-mcp-config-${Date.now()}-override.yaml`);
@@ -273,8 +223,7 @@ describe("loadConfig", () => {
         "  git_worktree_base_path: /tmp/default-worktrees",
         "  default_remote: upstream",
         "  allow_draft_prs: false",
-        "  branching_policies:",
-        "    - worktree",
+        "  workflow_mode: worktree",
         "repositories:",
         `  - path: ${repoDir}`,
         "    allowed_branch_patterns:",
@@ -283,9 +232,7 @@ describe("loadConfig", () => {
         "    git_worktree_base_path: /tmp/repo-worktrees",
         "    default_remote: origin",
         "    allow_draft_prs: true",
-        "    branching_policies:",
-        "      - current_branch",
-        "      - feature_branch",
+        "    workflow_mode: feature_branch",
       ].join("\n"),
       "utf8",
     );
@@ -297,50 +244,7 @@ describe("loadConfig", () => {
      expect(config.repositories[0]?.gitWorktreeBasePath).toBe(expectedWorktreeBasePath);
      expect(config.repositories[0]?.defaultRemote).toBe("origin");
     expect(config.repositories[0]?.allowDraftPrs).toBe(true);
-    expect(config.repositories[0]?.branchingPolicies).toEqual(["current_branch", "feature_branch"]);
-  });
-
-  it("appends always-allowed branch patterns to inherited defaults", async () => {
-    const repoDir = await fs.mkdtemp(path.join(os.tmpdir(), "git-mcp-defaults-plus-global-repo-"));
-    const configPath = path.join(os.tmpdir(), `git-mcp-config-${Date.now()}-defaults-plus-global.yaml`);
-    tempPaths.push(repoDir, configPath);
-
-    await fs.writeFile(
-      configPath,
-      [
-        "defaults:",
-        "  allowed_branch_patterns:",
-        '    - "^main$"',
-        'always_allowed_branch_patterns:',
-        '  - "^user/.+$"',
-        "repositories:",
-        `  - path: ${repoDir}`,
-      ].join("\n"),
-      "utf8",
-    );
-
-    const config = await loadConfig(configPath);
-
-    expect(config.repositories[0]?.allowedBranchPatterns.map((pattern) => pattern.source)).toEqual([
-      "^main$",
-      "^user\\/.+$",
-    ]);
-  });
-
-  it("accepts repositories that only rely on always-allowed branch patterns", async () => {
-    const repoDir = await fs.mkdtemp(path.join(os.tmpdir(), "git-mcp-global-only-repo-"));
-    const configPath = path.join(os.tmpdir(), `git-mcp-config-${Date.now()}-global-only.yaml`);
-    tempPaths.push(repoDir, configPath);
-
-    await fs.writeFile(
-      configPath,
-      ['always_allowed_branch_patterns:', '  - "^user/.+$"', "repositories:", `  - path: ${repoDir}`].join("\n"),
-      "utf8",
-    );
-
-    const config = await loadConfig(configPath);
-
-    expect(config.repositories[0]?.allowedBranchPatterns.map((pattern) => pattern.source)).toEqual(["^user\\/.+$"]);
+    expect(config.repositories[0]?.workflowMode).toBe("feature_branch");
   });
 
   it("rejects repositories without effective branch patterns", async () => {
@@ -351,7 +255,7 @@ describe("loadConfig", () => {
     await fs.writeFile(configPath, `repositories:\n  - path: ${repoDir}\n`, "utf8");
 
     await expect(loadConfig(configPath)).rejects.toThrow(
-      `repository '${repoDir}' must define allowed_branch_patterns directly, inherit them from top-level defaults, or rely on always_allowed_branch_patterns`,
+      `repository '${repoDir}' must define allowed_branch_patterns directly or inherit them from top-level defaults`,
     );
   });
 
@@ -391,8 +295,7 @@ describe("loadConfig", () => {
       [
         "repositories:",
         `  - path: ${repoDir}`,
-        "    branching_policies:",
-        "      - current_branch",
+        "    workflow_mode: current_branch",
         "    allowed_branch_patterns:",
         '      - "^main$"',
       ].join("\n"),
@@ -401,7 +304,7 @@ describe("loadConfig", () => {
 
     const config = await loadConfig(configPath);
 
-    expect(config.repositories[0]?.branchingPolicies).toEqual(["current_branch"]);
+    expect(config.repositories[0]?.workflowMode).toBe("current_branch");
   });
 
   it("rejects relative git_worktree_base_path values", async () => {
@@ -442,7 +345,6 @@ describe("bootstrapConfig", () => {
 
     const result = await bootstrapConfig(configPath, {
       feature_branch_pattern: "owner/<feature-name>",
-      always_allowed_branch_patterns: ["^owner\\/.*$"],
       allow_draft_prs: true,
     });
 
@@ -451,7 +353,6 @@ describe("bootstrapConfig", () => {
         feature_branch_pattern: "owner/<feature-name>",
         allow_draft_prs: true,
       },
-      always_allowed_branch_patterns: ["^owner\\/.*$"],
       repositories: [],
     });
 
@@ -478,7 +379,7 @@ describe("upsertRepoConfig", () => {
     const result = await upsertRepoConfig(configPath, {
       repo_path: repoDir,
       allowed_branch_patterns: ["^owner\\/.*$"],
-      branching_policies: ["worktree"],
+      workflow_mode: "worktree",
     });
 
     expect(result).toEqual({
@@ -486,14 +387,14 @@ describe("upsertRepoConfig", () => {
       repo: {
         path: repoDir,
         allowed_branch_patterns: ["^owner\\/.*$"],
-        branching_policies: ["worktree"],
+        workflow_mode: "worktree",
       },
     });
 
     const config = await loadConfig(configPath);
     expect(config.repositories).toHaveLength(1);
     expect(config.repositories[0]?.path).toBe(repoDir);
-    expect(config.repositories[0]?.branchingPolicies).toEqual(["worktree"]);
+    expect(config.repositories[0]?.workflowMode).toBe("worktree");
   });
 
   it("updates an existing repo entry matched by canonical path", async () => {
@@ -519,7 +420,7 @@ describe("upsertRepoConfig", () => {
     const result = await upsertRepoConfig(configPath, {
       repo_path: aliasDir,
       default_remote: "origin",
-      branching_policies: ["worktree"],
+      workflow_mode: "worktree",
     });
 
     expect(result).toEqual({
@@ -528,14 +429,14 @@ describe("upsertRepoConfig", () => {
         path: repoDir,
         allowed_branch_patterns: ["^owner/.*$"],
         default_remote: "origin",
-        branching_policies: ["worktree"],
+        workflow_mode: "worktree",
       },
     });
 
     const nextConfig = await loadConfig(configPath);
     expect(nextConfig.repositories).toHaveLength(1);
     expect(nextConfig.repositories[0]?.defaultRemote).toBe("origin");
-    expect(nextConfig.repositories[0]?.branchingPolicies).toEqual(["worktree"]);
+    expect(nextConfig.repositories[0]?.workflowMode).toBe("worktree");
   });
 
   it("rejects invalid branch regex updates", async () => {

--- a/tests/gitBranchCreateAndSwitch.test.ts
+++ b/tests/gitBranchCreateAndSwitch.test.ts
@@ -133,7 +133,7 @@ describe("gitBranchCreateAndSwitch", () => {
     ).rejects.toBeInstanceOf(BranchNameNotAllowedError);
   });
 
-  it("rejects branch creation when branching_policies excludes feature_branch", async () => {
+  it("rejects branch creation when workflow_mode excludes feature_branch", async () => {
     const { repoDir, repo } = await createTempGitRepo();
     tempPaths.push(repoDir);
 
@@ -141,14 +141,14 @@ describe("gitBranchCreateAndSwitch", () => {
       gitBranchCreateAndSwitch(
         {
           ...repo,
-          branchingPolicies: ["worktree"],
+          workflowMode: "worktree",
         },
         { newBranch: "feature/from-branch-tool" },
       ),
     ).rejects.toBeInstanceOf(BranchingPolicyViolationError);
   });
 
-  it("rejects branch creation when branching_policies excludes feature_branch via current_branch-only mode", async () => {
+  it("rejects branch creation when workflow_mode is current_branch", async () => {
     const { repoDir, repo } = await createTempGitRepo();
     tempPaths.push(repoDir);
 
@@ -156,14 +156,14 @@ describe("gitBranchCreateAndSwitch", () => {
       gitBranchCreateAndSwitch(
         {
           ...repo,
-          branchingPolicies: ["current_branch"],
+          workflowMode: "current_branch",
         },
         { newBranch: "feature/from-current-branch" },
       ),
     ).rejects.toBeInstanceOf(BranchingPolicyViolationError);
   });
 
-  it("allows branch creation when branching_policies includes feature_branch among multiple strategies", async () => {
+  it("allows branch creation when workflow_mode is feature_branch", async () => {
     const { repoDir, repo } = await createTempGitRepo();
     const remoteDir = await createTempBareGitRepo();
     tempPaths.push(repoDir, remoteDir);
@@ -182,7 +182,7 @@ describe("gitBranchCreateAndSwitch", () => {
     const result = await gitBranchCreateAndSwitch(
       {
         ...repo,
-        branchingPolicies: ["worktree", "feature_branch"],
+        workflowMode: "feature_branch",
       },
       { newBranch: "feature/multi-strategy" },
     );

--- a/tests/gitRepoPolicy.test.ts
+++ b/tests/gitRepoPolicy.test.ts
@@ -14,8 +14,9 @@ describe("getGitRepoPolicy", () => {
       gitWorktreeBasePath: "/private/tmp/worktrees",
       defaultRemote: "origin",
       allowDraftPrs: true,
-      branchingPolicies: ["current_branch", "feature_branch"],
+      workflowMode: "feature_branch",
       policySource: "global",
+      repoOverridesApplied: true,
     };
 
     expect(getGitRepoPolicy(repo)).toEqual({
@@ -26,9 +27,10 @@ describe("getGitRepoPolicy", () => {
       gitWorktreeBasePath: "/private/tmp/worktrees",
       defaultRemote: "origin",
       allowDraftPrs: true,
-      branchingPolicies: ["current_branch", "feature_branch"],
+      workflowMode: "feature_branch",
       policySource: "global",
       repoLocalConfigPath: undefined,
+      repoOverridesApplied: true,
     });
   });
 });

--- a/tests/gitWorktreeAdd.test.ts
+++ b/tests/gitWorktreeAdd.test.ts
@@ -124,7 +124,7 @@ describe("gitWorktreeAdd", () => {
     ).rejects.toBeInstanceOf(BranchNameNotAllowedError);
   });
 
-  it("rejects worktree creation when branching_policies excludes worktree", async () => {
+  it("rejects worktree creation when workflow_mode excludes worktree", async () => {
     const { repoDir, repo } = await createTempGitRepo();
     tempPaths.push(repoDir);
 
@@ -132,7 +132,7 @@ describe("gitWorktreeAdd", () => {
       gitWorktreeAdd(
         {
           ...repo,
-          branchingPolicies: ["feature_branch"],
+          workflowMode: "feature_branch",
         },
         {
           path: "/tmp/git-mcp-policy-mismatch-worktree",
@@ -142,7 +142,7 @@ describe("gitWorktreeAdd", () => {
     ).rejects.toBeInstanceOf(BranchingPolicyViolationError);
   });
 
-  it("rejects worktree creation when branching_policies excludes worktree via current_branch-only mode", async () => {
+  it("rejects worktree creation when workflow_mode is current_branch", async () => {
     const { repoDir, repo } = await createTempGitRepo();
     tempPaths.push(repoDir);
 
@@ -150,7 +150,7 @@ describe("gitWorktreeAdd", () => {
       gitWorktreeAdd(
         {
           ...repo,
-          branchingPolicies: ["current_branch"],
+          workflowMode: "current_branch",
         },
         {
           path: "/tmp/git-mcp-current-branch-worktree",
@@ -160,7 +160,7 @@ describe("gitWorktreeAdd", () => {
     ).rejects.toBeInstanceOf(BranchingPolicyViolationError);
   });
 
-  it("allows worktree creation when branching_policies includes worktree among multiple strategies", async () => {
+  it("allows worktree creation when workflow_mode is worktree", async () => {
     const { repoDir, repo } = await createTempGitRepo();
     const remoteDir = await createTempBareGitRepo();
     const worktreeParentDir = await fs.mkdtemp(path.join(os.tmpdir(), "git-mcp-worktree-add-multi-parent-"));
@@ -182,7 +182,7 @@ describe("gitWorktreeAdd", () => {
     const result = await gitWorktreeAdd(
       {
         ...repo,
-        branchingPolicies: ["current_branch", "worktree"],
+        workflowMode: "worktree",
       },
       {
         path: worktreeDir,

--- a/tests/repoAuth.test.ts
+++ b/tests/repoAuth.test.ts
@@ -89,7 +89,7 @@ describe("resolveAllowedRepo", () => {
     expect(resolvedRepo.allowedBranchPatterns.map((pattern) => pattern.source)).toEqual(["^codex\\/.+$"]);
   });
 
-  it("allows matching global repo entries to override opted-in repo-local fields", async () => {
+  it("allows matching global repo entries to override repo-local policy", async () => {
     const { repoDir } = await createTempGitRepo();
     tempPaths.push(repoDir);
     const canonicalRepoDir = await fs.realpath(repoDir);
@@ -102,13 +102,7 @@ describe("resolveAllowedRepo", () => {
         'feature_branch_pattern: "owner/<feature-name>"',
         "git_worktree_base_path: .worktrees",
         "allow_draft_prs: true",
-        "branching_policies:",
-        "  - worktree",
-        "allow_global_repo_overrides:",
-        "  - feature_branch_pattern",
-        "  - git_worktree_base_path",
-        "  - allow_draft_prs",
-        "  - branching_policies",
+        "workflow_mode: worktree",
       ].join("\n"),
       "utf8",
     );
@@ -125,13 +119,15 @@ describe("resolveAllowedRepo", () => {
             gitWorktreeBasePath: "/tmp/global-worktrees",
             defaultRemote: "origin",
             allowDraftPrs: false,
-            branchingPolicies: ["current_branch"],
+            workflowMode: "current_branch",
             policySource: "global",
-            globalRepoOverrides: {
+            repoOverrides: {
+              allowedBranchPatterns: [/^main$/],
               featureBranchPattern: "bob/<feature-name>",
               gitWorktreeBasePath: "/tmp/global-worktrees",
+              defaultRemote: "origin",
               allowDraftPrs: false,
-              branchingPolicies: ["current_branch"],
+              workflowMode: "current_branch",
             },
           },
         ],
@@ -143,12 +139,13 @@ describe("resolveAllowedRepo", () => {
     expect(resolvedRepo.featureBranchPattern).toBe("bob/<feature-name>");
     expect(resolvedRepo.gitWorktreeBasePath).toBe("/tmp/global-worktrees");
     expect(resolvedRepo.allowDraftPrs).toBe(false);
-    expect(resolvedRepo.branchingPolicies).toEqual(["current_branch"]);
-    expect(resolvedRepo.defaultRemote).toBeUndefined();
-    expect(resolvedRepo.allowedBranchPatterns.map((pattern) => pattern.source)).toEqual(["^owner\\/.+$"]);
+    expect(resolvedRepo.workflowMode).toBe("current_branch");
+    expect(resolvedRepo.defaultRemote).toBe("origin");
+    expect(resolvedRepo.allowedBranchPatterns.map((pattern) => pattern.source)).toEqual(["^main$"]);
+    expect(resolvedRepo.repoOverridesApplied).toBe(true);
   });
 
-  it("does not apply matching global repo entry values without repo-local opt-in", async () => {
+  it("does not apply top-level defaults over repo-local policy", async () => {
     const { repoDir } = await createTempGitRepo();
     tempPaths.push(repoDir);
     const canonicalRepoDir = await fs.realpath(repoDir);
@@ -161,70 +158,13 @@ describe("resolveAllowedRepo", () => {
         'feature_branch_pattern: "owner/<feature-name>"',
         "git_worktree_base_path: .worktrees",
         "allow_draft_prs: true",
-        "branching_policies:",
-        "  - worktree",
+        "workflow_mode: worktree",
       ].join("\n"),
       "utf8",
     );
 
-    const resolvedRepo = await resolveAllowedRepo(
-      {
-        repositories: [
-          {
-            path: repoDir,
-            canonicalPath: canonicalRepoDir,
-            worktreePath: canonicalRepoDir,
-            allowedBranchPatterns: [/^main$/],
-            featureBranchPattern: "bob/<feature-name>",
-            gitWorktreeBasePath: "/tmp/global-worktrees",
-            defaultRemote: "origin",
-            allowDraftPrs: false,
-            branchingPolicies: ["current_branch"],
-            policySource: "global",
-            globalRepoOverrides: {
-              featureBranchPattern: "bob/<feature-name>",
-              gitWorktreeBasePath: "/tmp/global-worktrees",
-              allowDraftPrs: false,
-              branchingPolicies: ["current_branch"],
-            },
-          },
-        ],
-      },
-      repoDir,
-    );
-
-    expect(resolvedRepo.featureBranchPattern).toBe("owner/<feature-name>");
-    expect(resolvedRepo.gitWorktreeBasePath).toBe(path.join(canonicalRepoDir, ".worktrees"));
-    expect(resolvedRepo.allowDraftPrs).toBe(true);
-    expect(resolvedRepo.branchingPolicies).toEqual(["worktree"]);
-    expect(resolvedRepo.defaultRemote).toBeUndefined();
-    expect(resolvedRepo.allowedBranchPatterns.map((pattern) => pattern.source)).toEqual(["^owner\\/.+$"]);
-  });
-
-  it("does not let top-level defaults override repo-local policy", async () => {
-    const { repoDir } = await createTempGitRepo();
     const configPath = path.join(os.tmpdir(), `git-mcp-config-${Date.now()}-repo-local-defaults.yaml`);
-    tempPaths.push(repoDir, configPath);
-    const canonicalRepoDir = await fs.realpath(repoDir);
-
-    await fs.writeFile(
-      path.join(repoDir, ".git-unleash.yaml"),
-      [
-        "allowed_branch_patterns:",
-        '  - "^owner/.+$"',
-        'feature_branch_pattern: "owner/<feature-name>"',
-        "git_worktree_base_path: .worktrees",
-        "allow_draft_prs: true",
-        "branching_policies:",
-        "  - worktree",
-        "allow_global_repo_overrides:",
-        "  - feature_branch_pattern",
-        "  - git_worktree_base_path",
-        "  - allow_draft_prs",
-        "  - branching_policies",
-      ].join("\n"),
-      "utf8",
-    );
+    tempPaths.push(configPath);
 
     await fs.writeFile(
       configPath,
@@ -236,8 +176,7 @@ describe("resolveAllowedRepo", () => {
         "  git_worktree_base_path: /tmp/default-worktrees",
         "  default_remote: origin",
         "  allow_draft_prs: false",
-        "  branching_policies:",
-        "    - current_branch",
+        "  workflow_mode: current_branch",
         "repositories:",
         `  - path: ${repoDir}`,
       ].join("\n"),
@@ -251,9 +190,10 @@ describe("resolveAllowedRepo", () => {
     expect(resolvedRepo.featureBranchPattern).toBe("owner/<feature-name>");
     expect(resolvedRepo.gitWorktreeBasePath).toBe(path.join(canonicalRepoDir, ".worktrees"));
     expect(resolvedRepo.allowDraftPrs).toBe(true);
-    expect(resolvedRepo.branchingPolicies).toEqual(["worktree"]);
+    expect(resolvedRepo.workflowMode).toBe("worktree");
     expect(resolvedRepo.defaultRemote).toBeUndefined();
     expect(resolvedRepo.allowedBranchPatterns.map((pattern) => pattern.source)).toEqual(["^owner\\/.+$"]);
+    expect(resolvedRepo.repoOverridesApplied).toBe(false);
   });
 
   it("rejects repo-local config that sets default_remote", async () => {


### PR DESCRIPTION
Why
This project’s configuration model had grown harder to explain than the tool surface it supports. The biggest sources of complexity were the extra `always_allowed_branch_patterns` layer, the multi-value `branching_policies` field, and the mismatch between the intended repo-local precedence model and what the code and docs described.

This change collapses the model to a simpler precedence rule: repo-local policy replaces `defaults` when present, and a matching repository entry in user config remains the only override layer. It also replaces multi-value workflow policy with a single `workflow_mode`, which matches how enforcement already behaves in practice.

Impact
The expected result is a smaller config grammar, clearer `git_repo_policy` output, and documentation that matches the actual behavior. Tests now cover repo-local-as-base precedence, repo-entry overrides, and the simplified workflow mode behavior.

The main risk is config compatibility for callers still using `always_allowed_branch_patterns` or `branching_policies`; those configs now need to be updated to the simplified model.

Closes #52