### PR TITLE
Escape <user> placeholders before branch regex compilation

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -336,12 +336,22 @@ function resolveFeatureBranchPattern(pattern: string | undefined): string | unde
   return resolveUserPlaceholder(pattern);
 }
 
-function resolveUserPlaceholder(value: string | undefined): string | undefined {
+function resolveUserPlaceholder(
+  value: string | undefined,
+  options: { escapeForRegex?: boolean } = {},
+): string | undefined {
   if (!value?.includes("<user>")) {
     return value;
   }
 
-  return value.replaceAll("<user>", resolveRuntimeUsername());
+  const runtimeUsername = resolveRuntimeUsername();
+  const replacement = options.escapeForRegex ? escapeRegexLiteral(runtimeUsername) : runtimeUsername;
+
+  return value.replaceAll("<user>", replacement);
+}
+
+function escapeRegexLiteral(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 function resolveRuntimeUsername(): string {
@@ -459,7 +469,7 @@ async function canonicalizeProspectivePath(inputPath: string): Promise<string> {
 
 function compileBranchPatterns(patterns: string[], repoPath: string): RegExp[] {
   return patterns.map((pattern) => {
-    const resolvedPattern = resolveUserPlaceholder(pattern) ?? pattern;
+    const resolvedPattern = resolveUserPlaceholder(pattern, { escapeForRegex: true }) ?? pattern;
 
     try {
       return new RegExp(resolvedPattern);

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -122,6 +122,57 @@ describe("loadConfig", () => {
     expect(config.repositories[0]?.allowedBranchPatterns.map((pattern) => pattern.source)).toEqual(["^codex\\/.+$"]);
   });
 
+  it("escapes regex metacharacters when resolving <user> in allowed branch patterns", async () => {
+    const repoDir = await fs.mkdtemp(path.join(os.tmpdir(), "git-mcp-user-escaped-pattern-repo-"));
+    const configPath = path.join(os.tmpdir(), `git-mcp-config-${Date.now()}-user-escaped-pattern.yaml`);
+    tempPaths.push(repoDir, configPath);
+    vi.stubEnv("USER", "john.doe+dev");
+    vi.stubEnv("USERNAME", "");
+
+    await fs.writeFile(
+      configPath,
+      [
+        "defaults:",
+        "  allowed_branch_patterns:",
+        '    - "^<user>/.+$"',
+        "repositories:",
+        `  - path: ${repoDir}`,
+      ].join("\n"),
+      "utf8",
+    );
+
+    const config = await loadConfig(configPath);
+    const [pattern] = config.repositories[0]?.allowedBranchPatterns ?? [];
+
+    expect(pattern?.source).toBe("^john\\.doe\\+dev\\/.+$");
+    expect(pattern?.test("john.doe+dev/feature")).toBe(true);
+    expect(pattern?.test("johnXdoe+dev/feature")).toBe(false);
+  });
+
+  it("keeps feature branch patterns advisory when resolving <user> with regex metacharacters", async () => {
+    const repoDir = await fs.mkdtemp(path.join(os.tmpdir(), "git-mcp-user-feature-pattern-repo-"));
+    const configPath = path.join(os.tmpdir(), `git-mcp-config-${Date.now()}-user-feature-pattern.yaml`);
+    tempPaths.push(repoDir, configPath);
+    vi.stubEnv("USER", "john.doe+dev");
+    vi.stubEnv("USERNAME", "");
+
+    await fs.writeFile(
+      configPath,
+      [
+        "repositories:",
+        `  - path: ${repoDir}`,
+        "    allowed_branch_patterns:",
+        '      - "^<user>/.+$"',
+        '    feature_branch_pattern: "<user>/<feature-name>"',
+      ].join("\n"),
+      "utf8",
+    );
+
+    const config = await loadConfig(configPath);
+
+    expect(config.repositories[0]?.featureBranchPattern).toBe("john.doe+dev/<feature-name>");
+  });
+
   it("falls back to USERNAME before os.userInfo for <user> resolution", async () => {
     const repoDir = await fs.mkdtemp(path.join(os.tmpdir(), "git-mcp-username-pattern-repo-"));
     const configPath = path.join(os.tmpdir(), `git-mcp-config-${Date.now()}-username-pattern.yaml`);


### PR DESCRIPTION
## Why
The runtime username was substituted directly into allowed branch regex patterns before compilation. Usernames containing regex metacharacters like . or + could change the meaning of the regex and allow incorrect matches.

## What changed
- add regression coverage for usernames with regex metacharacters in allowed branch patterns
- escape the resolved <user> placeholder only when compiling allowed branch regexes
- keep feature branch suggestions advisory and unescaped

## Impact
- branch authorization now treats runtime usernames literally in compiled regexes
- feature branch suggestions keep the original username text
- no change to the advisory feature branch pattern format

## Validation
- /opt/homebrew/bin/npm run typecheck
- ./node_modules/.bin/tsx runtime verification for escaped matching and unescaped feature branch suggestions
- /opt/homebrew/bin/npm test -- tests/config.test.ts is currently blocked here by a Vitest rolldown native binding startup error

Closes #54