### PR TITLE
Mitigate ReDoS risk in branch pattern matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Notes:
 - `feature_branch` means the preferred setup flow is `git_branch_create_and_switch`
 - `current_branch` means do not create a new worktree or feature branch; work directly on the current allowed branch
 - branch patterns are full-match regexes against the current branch name
+- keep branch patterns simple: advanced group syntax, backreferences, and nested quantifiers are rejected at config load time
 - each repository must end up with at least one effective allowed branch pattern, either from the repo entry or inherited `defaults`
 - `git_repo_policy` returns the configured branch patterns and related repository defaults for an authorized repository, including `feature_branch_pattern`, `git_worktree_base_path`, `workflow_mode`, the policy source, whether repo overrides were applied, and the repo-local config path when applicable
 - `git_add`, `git_commit`, `git_push`, and `gh_pr_create_draft` require the current branch to match one of the configured patterns

--- a/src/auth/branchAuth.ts
+++ b/src/auth/branchAuth.ts
@@ -2,6 +2,8 @@ import { BranchNameNotAllowedError, BranchNotAllowedError, DetachedHeadError } f
 import { getCurrentBranch } from "../exec/git.js";
 import type { RepoPolicy } from "../types/config.js";
 
+const fullMatchCache = new WeakMap<RegExp, RegExp>();
+
 export async function requireAllowedBranch(repo: RepoPolicy): Promise<string> {
   const branch = await getCurrentBranch(repo.worktreePath);
   if (!branch) {
@@ -28,6 +30,12 @@ export function isAllowedBranchName(repo: RepoPolicy, branch: string): boolean {
 }
 
 export function fullMatch(pattern: RegExp, value: string): boolean {
-  const fullPattern = new RegExp(`^(?:${pattern.source})$`, pattern.flags);
+  let fullPattern = fullMatchCache.get(pattern);
+  if (!fullPattern) {
+    fullPattern = new RegExp(`^(?:${pattern.source})$`, pattern.flags);
+    fullMatchCache.set(pattern, fullPattern);
+  }
+
+  fullPattern.lastIndex = 0;
   return fullPattern.test(value);
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -461,6 +461,8 @@ function compileBranchPatterns(patterns: string[], repoPath: string): RegExp[] {
   return patterns.map((pattern) => {
     const resolvedPattern = resolveUserPlaceholder(pattern) ?? pattern;
 
+    validateSafeBranchPattern(resolvedPattern, repoPath);
+
     try {
       return new RegExp(resolvedPattern);
     } catch (error) {
@@ -471,6 +473,153 @@ function compileBranchPatterns(patterns: string[], repoPath: string): RegExp[] {
       );
     }
   });
+}
+
+function validateSafeBranchPattern(pattern: string, repoPath: string): void {
+  const groups: Array<{ containsQuantifier: boolean }> = [];
+  let inCharClass = false;
+
+  for (let index = 0; index < pattern.length; index += 1) {
+    const char = pattern[index]!;
+
+    if (char === "\\") {
+      const nextChar = pattern[index + 1];
+      if (!inCharClass) {
+        if (nextChar && /[1-9]/.test(nextChar)) {
+          throw new ConfigError(
+            `branch regex '${pattern}' for repository '${repoPath}' uses unsupported backreferences; keep allowed_branch_patterns simple`,
+          );
+        }
+
+        if (nextChar === "k" && pattern[index + 2] === "<") {
+          throw new ConfigError(
+            `branch regex '${pattern}' for repository '${repoPath}' uses unsupported named backreferences; keep allowed_branch_patterns simple`,
+          );
+        }
+      }
+
+      index += 1;
+      continue;
+    }
+
+    if (inCharClass) {
+      if (char === "]") {
+        inCharClass = false;
+      }
+
+      continue;
+    }
+
+    if (char === "[") {
+      inCharClass = true;
+      continue;
+    }
+
+    if (char === "(") {
+      if (pattern[index + 1] === "?") {
+        if (pattern[index + 2] !== ":") {
+          throw new ConfigError(
+            `branch regex '${pattern}' for repository '${repoPath}' uses unsupported advanced group syntax; keep allowed_branch_patterns simple`,
+          );
+        }
+
+        index += 2;
+      }
+
+      groups.push({ containsQuantifier: false });
+      continue;
+    }
+
+    if (char === ")") {
+      const group = groups.pop();
+      if (!group) {
+        continue;
+      }
+
+      const quantifier = readRegexQuantifier(pattern, index + 1);
+      if (quantifier && group.containsQuantifier) {
+        throw new ConfigError(
+          `branch regex '${pattern}' for repository '${repoPath}' uses nested quantifiers; keep allowed_branch_patterns simple`,
+        );
+      }
+
+      const parentGroup = groups.at(-1);
+      if (parentGroup && (group.containsQuantifier || Boolean(quantifier))) {
+        parentGroup.containsQuantifier = true;
+      }
+
+      if (quantifier) {
+        index = quantifier.end - 1;
+      }
+
+      continue;
+    }
+
+    const quantifier = readRegexQuantifier(pattern, index);
+    if (quantifier) {
+      const group = groups.at(-1);
+      if (group) {
+        group.containsQuantifier = true;
+      }
+
+      index = quantifier.end - 1;
+    }
+  }
+}
+
+function readRegexQuantifier(pattern: string, index: number): { end: number } | undefined {
+  const char = pattern[index];
+  if (!char) {
+    return undefined;
+  }
+
+  if (char === "*" || char === "+" || char === "?") {
+    return {
+      end: pattern[index + 1] === "?" ? index + 2 : index + 1,
+    };
+  }
+
+  if (char !== "{") {
+    return undefined;
+  }
+
+  let cursor = index + 1;
+  if (!isAsciiDigit(pattern[cursor])) {
+    return undefined;
+  }
+
+  while (isAsciiDigit(pattern[cursor])) {
+    cursor += 1;
+  }
+
+  if (pattern[cursor] === "}") {
+    cursor += 1;
+    return {
+      end: pattern[cursor] === "?" ? cursor + 1 : cursor,
+    };
+  }
+
+  if (pattern[cursor] !== ",") {
+    return undefined;
+  }
+
+  cursor += 1;
+  while (isAsciiDigit(pattern[cursor])) {
+    cursor += 1;
+  }
+
+  if (pattern[cursor] !== "}") {
+    return undefined;
+  }
+
+  cursor += 1;
+  return {
+    end: pattern[cursor] === "?" ? cursor + 1 : cursor,
+  };
+}
+
+function isAsciiDigit(char: string | undefined): boolean {
+  return Boolean(char && /[0-9]/.test(char));
 }
 
 async function configFileExists(configPath: string): Promise<boolean> {

--- a/tests/branchAuth.test.ts
+++ b/tests/branchAuth.test.ts
@@ -10,4 +10,11 @@ describe("fullMatch", () => {
   it("does not match only a substring", () => {
     expect(fullMatch(/feature\/[a-z0-9._-]+/, "x/feature/test-1")).toBe(false);
   });
+
+  it("resets cached global regex state between calls", () => {
+    const pattern = /feature\/[a-z0-9._-]+/g;
+
+    expect(fullMatch(pattern, "feature/test-1")).toBe(true);
+    expect(fullMatch(pattern, "feature/test-1")).toBe(true);
+  });
 });

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -451,4 +451,30 @@ describe("upsertRepoConfig", () => {
       }),
     ).rejects.toThrow(`invalid branch regex '[' for repository '${repoDir}'`);
   });
+
+  it("rejects nested-quantifier branch regex updates", async () => {
+    const repoDir = await fs.mkdtemp(path.join(os.tmpdir(), "git-mcp-upsert-unsafe-regex-repo-"));
+    const configPath = path.join(os.tmpdir(), `git-mcp-config-${Date.now()}-upsert-unsafe-regex.yaml`);
+    tempPaths.push(repoDir, configPath);
+
+    await expect(
+      upsertRepoConfig(configPath, {
+        repo_path: repoDir,
+        allowed_branch_patterns: ["^(a+)+$"],
+      }),
+    ).rejects.toThrow(`branch regex '^(a+)+$' for repository '${repoDir}' uses nested quantifiers`);
+  });
+
+  it("rejects advanced group syntax in branch regex updates", async () => {
+    const repoDir = await fs.mkdtemp(path.join(os.tmpdir(), "git-mcp-upsert-advanced-group-repo-"));
+    const configPath = path.join(os.tmpdir(), `git-mcp-config-${Date.now()}-upsert-advanced-group.yaml`);
+    tempPaths.push(repoDir, configPath);
+
+    await expect(
+      upsertRepoConfig(configPath, {
+        repo_path: repoDir,
+        allowed_branch_patterns: ["(?=main$)main"],
+      }),
+    ).rejects.toThrow(`branch regex '(?=main$)main' for repository '${repoDir}' uses unsupported advanced group syntax`);
+  });
 });


### PR DESCRIPTION
## Why
Branch patterns come from repo or global config and were being compiled without any guardrails. That allowed expensive expressions such as `^(a+)+$` to reach authorization checks, creating a low-probability but real ReDoS footgun on every tool call.

## What changed
- add regression coverage for unsafe branch-pattern inputs
- reject advanced group syntax, backreferences, and nested quantifiers during config load
- cache the anchored full-match regex used during branch authorization to avoid recompiling it on every check
- document the new expectation that branch patterns stay simple

## Verification
- `bun x tsc --noEmit -p tsconfig.json`
- `bun /tmp/verify-issue-46.mjs`
- `vitest` is still blocked in this environment by a local `rolldown` native-binding signing issue

Closes #46