### PR TITLE
Enforce git_branch_switch target branch authorization

### DIFF
--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -386,8 +386,10 @@ Validation:
 
 - repository path is required
 - repository must be allowlisted
+- `workflow_mode` must be unset or `feature_branch`
 - worktree must be clean
 - `branch` must be non-empty after trimming
+- `branch` must match the configured allowed branch patterns
 - `branch` must already exist locally
 - no arbitrary ref checkout or detached checkout
 

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Notes:
 - when `git_worktree_base_path` is configured, `git_worktree_add.path` must resolve under that base path
 - `git_branch_create_and_switch` and `git_branch_switch` require a clean worktree
 - `git_branch_create_and_switch` also requires the requested new branch name to match `allowed_branch_patterns`, and is only allowed when `workflow_mode` is unset or `feature_branch`
+- `git_branch_switch` also requires the requested branch name to match `allowed_branch_patterns`, and is only allowed when `workflow_mode` is unset or `feature_branch`
 - remote resolution prefers configured `default_remote` when present and valid, then the current branch's remote, then `origin`
 - branch creation and PR base resolution prefer the remote HEAD branch and fall back to GitHub default-branch detection when needed
 - `git_status` only requires the repository to be authorized

--- a/src/server.ts
+++ b/src/server.ts
@@ -257,7 +257,7 @@ export function createServer(configPath: string): McpServer {
 
   server.tool(
     "git_branch_switch",
-    "Switch to an existing local branch in an authorized repository. This tool mutates repository state, requires the worktree to be clean, only accepts an explicit local branch name, and does not create branches or allow detached checkouts.",
+    "Switch to an existing local branch in an authorized repository. This tool mutates repository state, requires the worktree to be clean, requires the target branch name to match configured allowed patterns, is only allowed when workflow_mode is unset or feature_branch, only accepts an explicit local branch name, and does not create branches or allow detached checkouts.",
     {
       repo_path: z.string().min(1),
       branch: z.string(),

--- a/src/tools/gitBranchSwitch.ts
+++ b/src/tools/gitBranchSwitch.ts
@@ -1,3 +1,5 @@
+import { requireAllowedBranchName } from "../auth/branchAuth.js";
+import { requireWorkflowMode } from "../auth/branchingPolicy.js";
 import { BranchNotFoundError, DirtyWorktreeError, EmptyBranchNameError } from "../errors.js";
 import { branchExists, switchBranch } from "../exec/git.js";
 import type { RepoPolicy } from "../types/config.js";
@@ -8,10 +10,13 @@ export type GitBranchSwitchResult = {
 };
 
 export async function gitBranchSwitch(repo: RepoPolicy, branch: string): Promise<GitBranchSwitchResult> {
+  requireWorkflowMode(repo, "git_branch_switch", ["feature_branch"]);
+
   const normalizedBranch = branch.trim();
   if (!normalizedBranch) {
     throw new EmptyBranchNameError();
   }
+  requireAllowedBranchName(repo, normalizedBranch);
 
   const status = await getGitStatus(repo);
   if (!status.isClean) {

--- a/tests/gitBranchSwitch.test.ts
+++ b/tests/gitBranchSwitch.test.ts
@@ -3,7 +3,13 @@ import path from "node:path";
 
 import { afterEach, describe, expect, it } from "vitest";
 
-import { BranchNotFoundError, DirtyWorktreeError, EmptyBranchNameError } from "../src/errors.js";
+import {
+  BranchNameNotAllowedError,
+  BranchNotFoundError,
+  BranchingPolicyViolationError,
+  DirtyWorktreeError,
+  EmptyBranchNameError,
+} from "../src/errors.js";
 import { getCurrentBranch, gitSwitchBranchArgs } from "../src/exec/git.js";
 import { runCommand } from "../src/exec/run.js";
 import { gitAdd } from "../src/tools/gitAdd.js";
@@ -61,11 +67,87 @@ describe("gitBranchSwitch", () => {
     await expect(gitBranchSwitch(repo, "feature/missing")).rejects.toBeInstanceOf(BranchNotFoundError);
   });
 
+  it("rejects branch names that do not match allowed patterns", async () => {
+    const { repoDir, repo } = await createTempGitRepo();
+    tempPaths.push(repoDir);
+
+    await expect(
+      gitBranchSwitch(
+        {
+          ...repo,
+          allowedBranchPatterns: [/^feature\/.+$/],
+        },
+        "main",
+      ),
+    ).rejects.toBeInstanceOf(BranchNameNotAllowedError);
+  });
+
   it("rejects empty branch names", async () => {
     const { repoDir, repo } = await createTempGitRepo();
     tempPaths.push(repoDir);
 
     await expect(gitBranchSwitch(repo, "   ")).rejects.toBeInstanceOf(EmptyBranchNameError);
+  });
+
+  it("rejects switching when workflow_mode excludes feature_branch", async () => {
+    const { repoDir, repo } = await createTempGitRepo();
+    tempPaths.push(repoDir);
+
+    await expect(
+      gitBranchSwitch(
+        {
+          ...repo,
+          workflowMode: "worktree",
+        },
+        "main",
+      ),
+    ).rejects.toBeInstanceOf(BranchingPolicyViolationError);
+  });
+
+  it("rejects switching when workflow_mode is current_branch", async () => {
+    const { repoDir, repo } = await createTempGitRepo();
+    tempPaths.push(repoDir);
+
+    await expect(
+      gitBranchSwitch(
+        {
+          ...repo,
+          workflowMode: "current_branch",
+        },
+        "main",
+      ),
+    ).rejects.toBeInstanceOf(BranchingPolicyViolationError);
+  });
+
+  it("allows switching when workflow_mode is feature_branch", async () => {
+    const { repoDir, repo } = await createTempGitRepo();
+    const remoteDir = await createTempBareGitRepo();
+    tempPaths.push(repoDir, remoteDir);
+
+    await runCommand({ cwd: repoDir, command: "git", argv: ["remote", "add", "origin", remoteDir] });
+    await fs.writeFile(path.join(repoDir, "README.md"), "hello\n", "utf8");
+    await gitAdd(repo, ["README.md"]);
+    await gitCommit(repo, "add readme");
+    await gitPush(repo, "main");
+    await runCommand({
+      cwd: remoteDir,
+      command: "git",
+      argv: ["symbolic-ref", "HEAD", "refs/heads/main"],
+    });
+    await gitBranchCreateAndSwitch(repo, { newBranch: "feature/switch-me" });
+    await gitBranchSwitch(repo, "main");
+
+    const result = await gitBranchSwitch(
+      {
+        ...repo,
+        workflowMode: "feature_branch",
+      },
+      "feature/switch-me",
+    );
+    const currentBranch = await getCurrentBranch(repoDir);
+
+    expect(result).toEqual({ branch: "feature/switch-me" });
+    expect(currentBranch).toBe("feature/switch-me");
   });
 
   it("uses a fixed branch switch argument shape", () => {


### PR DESCRIPTION
## Why
`git_branch_switch` was the one mutating branch-setup tool that still skipped target-branch authorization. That let an agent switch onto any existing local branch even when the repo policy only allowed a narrower branch set. This change brings `git_branch_switch` back in line with the rest of the constrained workflow by enforcing the requested branch name against `allowed_branch_patterns` and honoring `workflow_mode` before the switch happens.

## Impact
Allowed switches on authorized feature branches keep working, but attempts to switch to disallowed branches or to use the tool outside `feature_branch` mode now fail fast instead of moving the worktree onto an unauthorized branch. I also updated the regression coverage and public docs so the tool contract matches the implementation.

Closes #45