### PR TITLE
Add constrained git_sync_base tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Current tool surface:
 - `git_add`
 - `git_commit`
 - `git_fetch`
+- `git_sync_base`
 - `git_worktree_add`
 - `git_push`
 - `git_branch_create_and_switch`
@@ -94,8 +95,9 @@ Notes:
 - keep branch patterns simple: advanced group syntax, backreferences, and nested quantifiers are rejected at config load time
 - each repository must end up with at least one effective allowed branch pattern, either from the repo entry or inherited `defaults`
 - `git_repo_policy` returns the configured branch patterns and related repository defaults for an authorized repository, including `feature_branch_pattern`, `git_worktree_base_path`, `workflow_mode`, the policy source, whether repo overrides were applied, and the repo-local config path when applicable
-- `git_add`, `git_commit`, `git_push`, and `gh_pr_create_draft` require the current branch to match one of the configured patterns
+- `git_add`, `git_commit`, `git_sync_base`, `git_push`, and `gh_pr_create_draft` require the current branch to match one of the configured patterns
 - `git_fetch` only requires the repository to be authorized, fetches from the resolved remote, and uses an explicit branch when provided or the detected base branch otherwise
+- `git_sync_base` requires a clean worktree, fetches the detected remote base branch, merges only that remote-tracking ref into the current allowed branch, and aborts the merge before returning an error if a conflict occurs
 - `git_worktree_add` requires an explicit absolute target path, validates the requested new branch name against `allowed_branch_patterns`, creates a linked worktree from an explicit or detected upstream base branch, and is only allowed when `workflow_mode` is unset or `worktree`
 - when `git_worktree_base_path` is configured, `git_worktree_add.path` must resolve under that base path
 - `git_branch_create_and_switch` and `git_branch_switch` require a clean worktree
@@ -179,10 +181,11 @@ The intended happy path is:
 5. Before creating a branch, use `git_repo_policy` to confirm the configured `allowed_branch_patterns`, then choose a new branch name that matches that policy.
 6. Call `git_branch_create_and_switch` to branch from an explicit or detected upstream base when you need a new local branch in the current worktree.
 7. Call `git_worktree_add` when you need a separate linked worktree on a new allowed branch at an explicit absolute path.
-8. Call `git_add` with explicit repository-relative paths.
-9. Call `git_commit` with a normal commit message.
-10. Call `git_push` to push the current branch to the resolved remote.
-11. Call `gh_pr_create_draft` to open a draft PR against an explicit base or the detected default base branch.
+8. Call `git_sync_base` when you need to bring the detected remote base branch into the current allowed branch without exposing generic merge controls.
+9. Call `git_add` with explicit repository-relative paths.
+10. Call `git_commit` with a normal commit message.
+11. Call `git_push` to push the current branch to the resolved remote.
+12. Call `gh_pr_create_draft` to open a draft PR against an explicit base or the detected default base branch.
 
 Each step stays inside a fixed policy boundary. There is no arbitrary checkout, no arbitrary push refspec, no amend flow, and no non-draft PR creation.
 
@@ -273,6 +276,7 @@ Once registered, Codex should be able to use:
 - `git_add` for repository-relative paths inside an authorized repository; it rejects absolute paths and repository-escaping paths like `../x`
 - `git_commit` with a normal commit message on an allowed branch; it rejects empty commit messages and empty commits
 - `git_fetch` to fetch a plain branch name from the detected remote; it does not allow arbitrary fetch arguments or refspecs and uses an explicit branch when provided or the detected base branch otherwise
+- `git_sync_base` to merge the detected remote base branch into the current allowed branch; it requires a clean worktree, does not allow arbitrary refs or merge flags, and aborts on conflict before returning an error
 - `git_worktree_add` to create a linked worktree for a new allowed branch at an explicit absolute path; it fetches the explicit or detected base branch first, does not allow arbitrary refs, and enforces `git_worktree_base_path` when configured
 - `git_branch_create_and_switch` to create a local branch from an explicit or detected upstream base and switch to it; it rejects requested branch names that do not match the configured allowed branch patterns
 - `git_branch_switch` to switch to an existing local branch when the worktree is clean; it does not create branches or allow detached checkouts
@@ -287,9 +291,9 @@ When the global config file is missing, runtime tools remain registered. They ca
 
 Some operations resolve defaults at runtime instead of requiring everything to be pinned in config.
 
-- `git_fetch`, `git_push`, `git_worktree_add`, `git_branch_create_and_switch`, and `gh_pr_create_draft` resolve the remote by preferring configured `default_remote`, then the current branch remote, then `origin`
+- `git_fetch`, `git_sync_base`, `git_push`, `git_worktree_add`, `git_branch_create_and_switch`, and `gh_pr_create_draft` resolve the remote by preferring configured `default_remote`, then the current branch remote, then `origin`
 - `git_fetch`, `git_worktree_add`, `git_branch_create_and_switch`, and `gh_pr_create_draft` accept an explicit branch or base input
-- `git_fetch`, `git_worktree_add`, `git_branch_create_and_switch`, and `gh_pr_create_draft` resolve their default branch or base by preferring the remote HEAD branch and falling back to the GitHub repository default branch when no explicit input is provided
+- `git_fetch`, `git_sync_base`, `git_worktree_add`, `git_branch_create_and_switch`, and `gh_pr_create_draft` resolve their default branch or base by preferring the remote HEAD branch and falling back to the GitHub repository default branch when no explicit input is provided
 
 This keeps the tools constrained while still working across repositories that use different default branches or remotes.
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -67,6 +67,7 @@ At minimum, mutating operations include:
 
 - `git_add`
 - `git_commit`
+- `git_sync_base`
 - `git_push`
 - `gh_pr_create_draft`
 
@@ -118,6 +119,7 @@ The server may expose structured tools for operations such as:
 
 - repository inspection and policy inspection
 - constrained staging and commit creation
+- constrained base-branch synchronization into the current allowed branch
 - constrained branch creation and branch switching
 - constrained linked worktree creation
 - constrained remote synchronization

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -109,6 +109,13 @@ export class DirtyWorktreeError extends Error {
   }
 }
 
+export class GitSyncBaseConflictError extends Error {
+  constructor(repoPath: string, branch: string, baseRef: string) {
+    super(`could not sync branch '${branch}' in repository '${repoPath}' with base '${baseRef}' because the merge conflicted`);
+    this.name = "GitSyncBaseConflictError";
+  }
+}
+
 export class BranchNotFoundError extends Error {
   constructor(branch: string, repoPath: string) {
     super(`branch '${branch}' does not exist in repository '${repoPath}'`);

--- a/src/exec/git.ts
+++ b/src/exec/git.ts
@@ -26,6 +26,14 @@ export function gitCreateBranchArgs(newBranch: string, startPoint: string): stri
   return ["branch", newBranch, startPoint];
 }
 
+export function gitMergeArgs(ref: string): string[] {
+  return ["merge", "--no-edit", ref];
+}
+
+export function gitMergeAbortArgs(): string[] {
+  return ["merge", "--abort"];
+}
+
 export function gitWorktreeAddArgs(worktreePath: string, newBranch: string, startPoint: string): string[] {
   return ["worktree", "add", "-b", newBranch, worktreePath, startPoint];
 }
@@ -137,6 +145,22 @@ export async function createBranch(cwd: string, newBranch: string, startPoint: s
     cwd,
     command: "git",
     argv: gitCreateBranchArgs(newBranch, startPoint),
+  });
+}
+
+export async function mergeRefIntoCurrentBranch(cwd: string, ref: string): Promise<void> {
+  await runCommand({
+    cwd,
+    command: "git",
+    argv: gitMergeArgs(ref),
+  });
+}
+
+export async function abortMerge(cwd: string): Promise<void> {
+  await runCommand({
+    cwd,
+    command: "git",
+    argv: gitMergeAbortArgs(),
   });
 }
 
@@ -258,6 +282,17 @@ export async function hasWorkingTreeChanges(cwd: string, repoRelativePath: strin
     }
 
     throw error;
+  }
+}
+
+export async function hasMergeInProgress(cwd: string): Promise<boolean> {
+  const commonDir = await getGitCommonDir(cwd);
+
+  try {
+    await fs.access(path.join(commonDir, "MERGE_HEAD"));
+    return true;
+  } catch {
+    return false;
   }
 }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -16,6 +16,7 @@ import { gitFetch } from "./tools/gitFetch.js";
 import { gitPush } from "./tools/gitPush.js";
 import { getGitRepoPolicy } from "./tools/gitRepoPolicy.js";
 import { getGitStatus } from "./tools/gitStatus.js";
+import { gitSyncBase } from "./tools/gitSyncBase.js";
 import { gitWorktreeAdd } from "./tools/gitWorktreeAdd.js";
 
 const workflowModeSchema = z.enum(["worktree", "feature_branch", "current_branch"]);
@@ -58,6 +59,7 @@ export function getRegisteredToolNames(): string[] {
     "git_branch_create_and_switch",
     "git_branch_switch",
     "git_fetch",
+    "git_sync_base",
     "git_worktree_add",
     "git_push",
     "gh_pr_create_draft",
@@ -289,6 +291,28 @@ export function createServer(configPath: string): McpServer {
     async ({ repo_path, branch }) => {
       const repo = await resolveRuntimeRepo(configPath, repo_path);
       const result = await gitFetch(repo, { branch });
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(result, null, 2),
+          },
+        ],
+      };
+    },
+  );
+
+  server.tool(
+    "git_sync_base",
+    "Merge the detected remote base branch into the current allowed branch for an authorized repository. This tool requires a clean worktree, fetches the base branch first, does not accept arbitrary refs or merge flags, and aborts on conflict before returning an error.",
+    {
+      repo_path: z.string().min(1),
+    },
+    CLOSED_WORLD_POTENTIALLY_DESTRUCTIVE_MUTATION_TOOL,
+    async ({ repo_path }) => {
+      const repo = await resolveRuntimeRepo(configPath, repo_path);
+      const result = await gitSyncBase(repo);
 
       return {
         content: [

--- a/src/tools/gitSyncBase.ts
+++ b/src/tools/gitSyncBase.ts
@@ -1,0 +1,54 @@
+import { requireAllowedBranch } from "../auth/branchAuth.js";
+import { CommandExecutionError, DirtyWorktreeError, GitSyncBaseConflictError } from "../errors.js";
+import { abortMerge, hasMergeInProgress, mergeRefIntoCurrentBranch } from "../exec/git.js";
+import type { RepoPolicy } from "../types/config.js";
+import { getGitStatus } from "./gitStatus.js";
+import { gitFetch } from "./gitFetch.js";
+
+export type GitSyncBaseResult = {
+  branch: string;
+  remote: string;
+  base: string;
+  baseRef: string;
+};
+
+export async function gitSyncBase(repo: RepoPolicy): Promise<GitSyncBaseResult> {
+  const branch = await requireAllowedBranch(repo);
+  const status = await getGitStatus(repo);
+  if (!status.isClean) {
+    throw new DirtyWorktreeError(repo.worktreePath);
+  }
+
+  const { remote, branch: base } = await gitFetch(repo, {});
+  const baseRef = `refs/remotes/${remote}/${base}`;
+
+  try {
+    await mergeRefIntoCurrentBranch(repo.worktreePath, baseRef);
+  } catch (error) {
+    if (error instanceof CommandExecutionError) {
+      await abortMergeIfNeeded(repo.worktreePath);
+      throw new GitSyncBaseConflictError(repo.worktreePath, branch, baseRef);
+    }
+
+    throw error;
+  }
+
+  return {
+    branch,
+    remote,
+    base,
+    baseRef,
+  };
+}
+
+async function abortMergeIfNeeded(cwd: string): Promise<void> {
+  if (!(await hasMergeInProgress(cwd))) {
+    return;
+  }
+
+  try {
+    await abortMerge(cwd);
+  } catch {
+    // Best effort cleanup: callers should never be left in a merge flow when abort works.
+  }
+}

--- a/tests/gitArgs.test.ts
+++ b/tests/gitArgs.test.ts
@@ -6,6 +6,8 @@ import {
   gitCommitArgs,
   gitCreateBranchArgs,
   gitFetchBranchArgs,
+  gitMergeAbortArgs,
+  gitMergeArgs,
   gitPushArgs,
   gitRemoteGetUrlArgs,
   gitRemoteHeadArgs,
@@ -33,6 +35,11 @@ describe("git argument builders", () => {
 
   it("builds constrained git fetch arguments", () => {
     expect(gitFetchBranchArgs("origin", "main")).toEqual(["fetch", "origin", "main"]);
+  });
+
+  it("builds constrained git sync-base merge arguments", () => {
+    expect(gitMergeArgs("refs/remotes/origin/main")).toEqual(["merge", "--no-edit", "refs/remotes/origin/main"]);
+    expect(gitMergeAbortArgs()).toEqual(["merge", "--abort"]);
   });
 
   it("builds constrained git branch creation arguments", () => {

--- a/tests/gitSyncBase.test.ts
+++ b/tests/gitSyncBase.test.ts
@@ -1,0 +1,154 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { DirtyWorktreeError, GitSyncBaseConflictError } from "../src/errors.js";
+import { hasMergeInProgress } from "../src/exec/git.js";
+import { runCommand } from "../src/exec/run.js";
+import { gitAdd } from "../src/tools/gitAdd.js";
+import { gitBranchCreateAndSwitch } from "../src/tools/gitBranchCreateAndSwitch.js";
+import { gitCommit } from "../src/tools/gitCommit.js";
+import { gitPush } from "../src/tools/gitPush.js";
+import { gitSyncBase } from "../src/tools/gitSyncBase.js";
+import { createTempBareGitRepo, createTempGitRepo } from "./helpers.js";
+
+const tempPaths: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempPaths.splice(0).map((tempPath) => fs.rm(tempPath, { force: true, recursive: true })));
+});
+
+describe("gitSyncBase", () => {
+  it("merges the detected remote base branch into the current allowed branch", async () => {
+    const { repoDir, repo } = await createTempGitRepo();
+    const remoteDir = await createTempBareGitRepo();
+    const updaterDir = await fs.mkdtemp(path.join(path.dirname(repoDir), "git-mcp-sync-updater-"));
+    tempPaths.push(repoDir, remoteDir, updaterDir);
+
+    await runCommand({ cwd: repoDir, command: "git", argv: ["remote", "add", "origin", remoteDir] });
+    await fs.writeFile(path.join(repoDir, "README.md"), "hello\n", "utf8");
+    await gitAdd(repo, ["README.md"]);
+    await gitCommit(repo, "add readme");
+    await gitPush(repo, "main");
+    await runCommand({ cwd: remoteDir, command: "git", argv: ["symbolic-ref", "HEAD", "refs/heads/main"] });
+
+    await gitBranchCreateAndSwitch(
+      {
+        ...repo,
+        allowedBranchPatterns: [/^feature\/.+$/],
+      },
+      { newBranch: "feature/sync-base" },
+    );
+
+    await runCommand({ cwd: updaterDir, command: "git", argv: ["clone", remoteDir, "."] });
+    await runCommand({ cwd: updaterDir, command: "git", argv: ["config", "user.name", "Codex Test"] });
+    await runCommand({ cwd: updaterDir, command: "git", argv: ["config", "user.email", "codex@example.com"] });
+    await runCommand({ cwd: updaterDir, command: "git", argv: ["config", "commit.gpgsign", "false"] });
+    await fs.writeFile(path.join(updaterDir, "CHANGELOG.md"), "base update\n", "utf8");
+    await runCommand({ cwd: updaterDir, command: "git", argv: ["add", "CHANGELOG.md"] });
+    await runCommand({ cwd: updaterDir, command: "git", argv: ["commit", "-m", "remote update"] });
+    await runCommand({ cwd: updaterDir, command: "git", argv: ["push", "origin", "HEAD:refs/heads/main"] });
+
+    const result = await gitSyncBase({
+      ...repo,
+      worktreePath: repoDir,
+      allowedBranchPatterns: [/^feature\/.+$/],
+    });
+
+    const changelog = await fs.readFile(path.join(repoDir, "CHANGELOG.md"), "utf8");
+    const headOid = await runCommand({
+      cwd: repoDir,
+      command: "git",
+      argv: ["rev-parse", "--verify", "HEAD"],
+    });
+    const remoteMainOid = await runCommand({
+      cwd: repoDir,
+      command: "git",
+      argv: ["rev-parse", "--verify", "refs/remotes/origin/main"],
+    });
+
+    expect(result).toEqual({
+      branch: "feature/sync-base",
+      remote: "origin",
+      base: "main",
+      baseRef: "refs/remotes/origin/main",
+    });
+    expect(changelog).toBe("base update\n");
+    expect(headOid.stdout.trim()).toBe(remoteMainOid.stdout.trim());
+  });
+
+  it("rejects dirty worktrees before syncing", async () => {
+    const { repoDir, repo } = await createTempGitRepo();
+    tempPaths.push(repoDir);
+
+    await fs.writeFile(path.join(repoDir, "README.md"), "dirty\n", "utf8");
+
+    await expect(gitSyncBase(repo)).rejects.toBeInstanceOf(DirtyWorktreeError);
+  });
+
+  it("aborts the merge and raises a conflict error when sync conflicts", async () => {
+    const { repoDir, repo } = await createTempGitRepo();
+    const remoteDir = await createTempBareGitRepo();
+    const updaterDir = await fs.mkdtemp(path.join(path.dirname(repoDir), "git-mcp-conflict-updater-"));
+    tempPaths.push(repoDir, remoteDir, updaterDir);
+
+    await runCommand({ cwd: repoDir, command: "git", argv: ["remote", "add", "origin", remoteDir] });
+    await fs.writeFile(path.join(repoDir, "README.md"), "base\n", "utf8");
+    await gitAdd(repo, ["README.md"]);
+    await gitCommit(repo, "initial base");
+    await gitPush(repo, "main");
+    await runCommand({ cwd: remoteDir, command: "git", argv: ["symbolic-ref", "HEAD", "refs/heads/main"] });
+
+    await gitBranchCreateAndSwitch(
+      {
+        ...repo,
+        allowedBranchPatterns: [/^feature\/.+$/],
+      },
+      { newBranch: "feature/conflict-sync" },
+    );
+    await fs.writeFile(path.join(repoDir, "README.md"), "feature change\n", "utf8");
+    await gitAdd(
+      {
+        ...repo,
+        worktreePath: repoDir,
+        allowedBranchPatterns: [/^feature\/.+$/],
+      },
+      ["README.md"],
+    );
+    await gitCommit(
+      {
+        ...repo,
+        worktreePath: repoDir,
+        allowedBranchPatterns: [/^feature\/.+$/],
+      },
+      "feature update",
+    );
+
+    await runCommand({ cwd: updaterDir, command: "git", argv: ["clone", remoteDir, "."] });
+    await runCommand({ cwd: updaterDir, command: "git", argv: ["config", "user.name", "Codex Test"] });
+    await runCommand({ cwd: updaterDir, command: "git", argv: ["config", "user.email", "codex@example.com"] });
+    await runCommand({ cwd: updaterDir, command: "git", argv: ["config", "commit.gpgsign", "false"] });
+    await fs.writeFile(path.join(updaterDir, "README.md"), "base change\n", "utf8");
+    await runCommand({ cwd: updaterDir, command: "git", argv: ["add", "README.md"] });
+    await runCommand({ cwd: updaterDir, command: "git", argv: ["commit", "-m", "base update"] });
+    await runCommand({ cwd: updaterDir, command: "git", argv: ["push", "origin", "HEAD:refs/heads/main"] });
+
+    const featureRepo = {
+      ...repo,
+      worktreePath: repoDir,
+      allowedBranchPatterns: [/^feature\/.+$/],
+    };
+
+    await expect(gitSyncBase(featureRepo)).rejects.toBeInstanceOf(GitSyncBaseConflictError);
+    await expect(hasMergeInProgress(repoDir)).resolves.toBe(false);
+
+    const status = await runCommand({
+      cwd: repoDir,
+      command: "git",
+      argv: ["status", "--short"],
+    });
+
+    expect(status.stdout.trim()).toBe("");
+  });
+});

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -25,6 +25,7 @@ describe("getRegisteredToolNames", () => {
       "git_branch_create_and_switch",
       "git_branch_switch",
       "git_fetch",
+      "git_sync_base",
       "git_worktree_add",
       "git_push",
       "gh_pr_create_draft",
@@ -84,6 +85,11 @@ describe("createServer", () => {
         openWorldHint: false,
       },
       git_fetch: {
+        readOnlyHint: false,
+        destructiveHint: true,
+        openWorldHint: false,
+      },
+      git_sync_base: {
         readOnlyHint: false,
         destructiveHint: true,
         openWorldHint: false,


### PR DESCRIPTION
## Why
Agents can already fetch the base branch and create new branches/worktrees from it, but they cannot refresh an existing allowed branch with newer base commits. This adds that maintenance flow without exposing generic `git merge` behavior.

## Impact
Good:
- adds `git_sync_base` as a constrained tool that fetches the detected remote base branch and merges only that remote-tracking ref into the current allowed branch
- requires an allowed current branch and a clean worktree
- aborts the merge before returning a structured conflict error so callers are not left in merge state
- covers the new behavior with argv, server-registration, success, dirty-worktree, and conflict-cleanup tests

Potentially bad:
- merge failures are currently classified as sync conflicts after cleanup, so non-conflict merge failures are reported through the same structured error path

## Verification
- `npm run typecheck`
- `npm test`

Closes #67