### PR TITLE
Add lightweight GitHub issue templates and guidelines

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,13 @@
+---
+name: Bug / Risk
+about: Report incorrect behavior, a safety gap, or a policy regression.
+title: ""
+labels: bug
+assignees: ""
+---
+
+## Problem
+
+## Impact
+
+## Recommendation or possible fixes

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: GitHub issue guidelines
+    url: https://github.com/niamster/codex-git-unleash-mcp/blob/main/docs/github-issues.md
+    about: Read the repository's issue-title, body, and label conventions before opening a new issue.

--- a/.github/ISSUE_TEMPLATE/improvement.md
+++ b/.github/ISSUE_TEMPLATE/improvement.md
@@ -1,0 +1,11 @@
+---
+name: Improvement
+about: Propose a constrained improvement to the MCP server, policy model, or docs.
+title: ""
+labels: enhancement
+assignees: ""
+---
+
+## Why
+
+## Non-goals

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,3 +18,5 @@ Before creating a development worktree, call `git_unleash.git_repo_policy` first
 Note: other repositories may prefer `git_unleash.git_branch_create_and_switch` instead, especially very large repositories where creating an additional linked worktree is too expensive for the task.
 
 The Git and GitHub operations for the steps above must be performed using the `git_unleash` MCP.
+
+For GitHub issue conventions in this repository, see [docs/github-issues.md](./docs/github-issues.md).

--- a/docs/github-issues.md
+++ b/docs/github-issues.md
@@ -1,0 +1,43 @@
+# GitHub Issues
+
+Keep issues concise and concrete. This repository is small and policy-heavy, so issue bodies should describe the exact behavior gap or requested capability without extra ceremony.
+
+## Titles
+
+- Keep titles short and specific.
+- Avoid bracketed type prefixes such as `[feature]` or `[improvement]`.
+- Prefer the title to describe the actual problem or capability, not its label.
+
+## Labels
+
+- Let labels carry issue type and other classification.
+- Do not repeat label information in the title when a label already covers it.
+
+## Bodies
+
+Use the lightest template that still makes the issue easy to act on.
+
+### Improvement
+
+Use:
+
+- `Why`
+- `Non-goals`
+
+Add more sections only when they materially reduce ambiguity.
+
+### Bug / Risk
+
+Use:
+
+- `Problem`
+- `Impact`
+- `Recommendation or possible fixes`
+
+For policy or safety issues, describe both the behavior that is currently possible and the narrower behavior the repository should allow instead.
+
+## Scope
+
+- Prefer one concern per issue.
+- Keep recommendations constrained to this repository's explicit Git, GitHub, and policy boundary rather than generic platform changes.
+- When relevant, point to the exact files, tools, or policy rules involved.


### PR DESCRIPTION
## Why
The repository had no in-repo guidance or templates for GitHub issues. That made issue titles and bodies drift between terse feature requests, detailed risk reports, and ad hoc prefixes.

## What changed
- added lightweight Markdown issue templates for `Improvement` and `Bug / Risk`
- added an issue-template chooser config that links to the repo's issue guidelines
- added `docs/github-issues.md` with short conventions for issue titles, labels, and body structure
- linked the guidelines doc from `AGENTS.md`

## Impact
Good:
- new issues can start from the lightest structure that still captures intent
- improvements and bug/risk reports now follow shapes that match how this repo already discusses work
- issue titles can stay focused on the actual problem or capability instead of type prefixes

Potentially bad:
- the chooser links to the `main` branch copy of the guidelines doc, so the link is only fully useful once this PR lands
- existing older issues may still use the previous title/body style until they are touched again