### PR TITLE
Add current branch pull tool

### DIFF
--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -312,6 +312,27 @@ Output guidance:
 
 - return the resolved remote and the fetched branch
 
+### `git_pull_current_branch`
+
+Validation:
+
+- repository path is required
+- repository must be allowlisted
+- current branch must be authorized
+- worktree must be clean
+- detached HEAD is rejected
+
+Execution:
+
+- resolve the remote from configuration or constrained runtime defaults
+- fetch only the current branch from the resolved remote
+- merge only `refs/remotes/<remote>/<current-branch>` into the current branch
+- abort the merge before returning an error if a conflict occurs
+
+Output guidance:
+
+- return the current branch, resolved remote, and merged remote-tracking ref
+
 ### `git_push`
 
 Validation:
@@ -524,6 +545,7 @@ Live GitHub integration tests can be deferred until later.
 - `git_add`
 - `git_commit`
 - `git_fetch`
+- `git_pull_current_branch`
 - `git_worktree_add`
 - `git_push`
 - `git_branch_create_and_switch`

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Local MCP server for a narrow, policy-constrained set of Git and GitHub operations that Codex can call with fewer repeated shell and sandbox approval prompts.
 
-It exists to handle a small approved workflow through MCP tools: inspect repository state, stage and commit changes, fetch and push the current branch, create or switch local branches in a constrained way, and open draft pull requests.
+It exists to handle a small approved workflow through MCP tools: inspect repository state, stage and commit changes, fetch, pull, and push the current branch, create or switch local branches in a constrained way, and open draft pull requests.
 
 This is especially useful with OpenAI Codex sandbox, where protected-path behavior still applies to paths such as `.git`. In practice, shell Git operations that write repository metadata can still be blocked or require approval, while direct GitHub network mutations may still be allowed or approval-gated depending on runtime policy.
 
@@ -22,6 +22,7 @@ Current tool surface:
 - `git_commit`
 - `git_fetch`
 - `git_sync_base`
+- `git_pull_current_branch`
 - `git_worktree_add`
 - `git_push`
 - `git_branch_create_and_switch`
@@ -95,9 +96,10 @@ Notes:
 - keep branch patterns simple: advanced group syntax, backreferences, and nested quantifiers are rejected at config load time
 - each repository must end up with at least one effective allowed branch pattern, either from the repo entry or inherited `defaults`
 - `git_repo_policy` returns the configured branch patterns and related repository defaults for an authorized repository, including `feature_branch_pattern`, `git_worktree_base_path`, `workflow_mode`, the policy source, whether repo overrides were applied, and the repo-local config path when applicable
-- `git_add`, `git_commit`, `git_sync_base`, `git_push`, and `gh_pr_create_draft` require the current branch to match one of the configured patterns
+- `git_add`, `git_commit`, `git_sync_base`, `git_pull_current_branch`, `git_push`, and `gh_pr_create_draft` require the current branch to match one of the configured patterns
 - `git_fetch` only requires the repository to be authorized, fetches from the resolved remote, and uses an explicit branch when provided or the detected base branch otherwise
 - `git_sync_base` requires a clean worktree, fetches the detected remote base branch, merges only that remote-tracking ref into the current allowed branch, and aborts the merge before returning an error if a conflict occurs
+- `git_pull_current_branch` requires a clean worktree, fetches the current branch from the resolved remote, merges only that remote-tracking ref into the current allowed branch, and aborts the merge before returning an error if a conflict occurs
 - `git_worktree_add` requires an explicit absolute target path, validates the requested new branch name against `allowed_branch_patterns`, creates a linked worktree from an explicit or detected upstream base branch, and is only allowed when `workflow_mode` is unset or `worktree`
 - when `git_worktree_base_path` is configured, `git_worktree_add.path` must resolve under that base path
 - `git_branch_create_and_switch` and `git_branch_switch` require a clean worktree
@@ -182,10 +184,11 @@ The intended happy path is:
 6. Call `git_branch_create_and_switch` to branch from an explicit or detected upstream base when you need a new local branch in the current worktree.
 7. Call `git_worktree_add` when you need a separate linked worktree on a new allowed branch at an explicit absolute path.
 8. Call `git_sync_base` when you need to bring the detected remote base branch into the current allowed branch without exposing generic merge controls.
-9. Call `git_add` with explicit repository-relative paths.
-10. Call `git_commit` with a normal commit message.
-11. Call `git_push` to push the current branch to the resolved remote.
-12. Call `gh_pr_create_draft` to open a draft PR against an explicit base or the detected default base branch.
+9. Call `git_pull_current_branch` when you need to bring the current branch's resolved remote branch into the current allowed branch without exposing generic merge controls.
+10. Call `git_add` with explicit repository-relative paths.
+11. Call `git_commit` with a normal commit message.
+12. Call `git_push` to push the current branch to the resolved remote.
+13. Call `gh_pr_create_draft` to open a draft PR against an explicit base or the detected default base branch.
 
 Each step stays inside a fixed policy boundary. There is no arbitrary checkout, no arbitrary push refspec, no amend flow, and no non-draft PR creation.
 
@@ -277,6 +280,7 @@ Once registered, Codex should be able to use:
 - `git_commit` with a normal commit message on an allowed branch; it rejects empty commit messages and empty commits
 - `git_fetch` to fetch a plain branch name from the detected remote; it does not allow arbitrary fetch arguments or refspecs and uses an explicit branch when provided or the detected base branch otherwise
 - `git_sync_base` to merge the detected remote base branch into the current allowed branch; it requires a clean worktree, does not allow arbitrary refs or merge flags, and aborts on conflict before returning an error
+- `git_pull_current_branch` to fetch and merge the current branch from the detected remote into the current allowed branch; it requires a clean worktree, does not allow arbitrary refs or merge flags, and aborts on conflict before returning an error
 - `git_worktree_add` to create a linked worktree for a new allowed branch at an explicit absolute path; it fetches the explicit or detected base branch first, does not allow arbitrary refs, and enforces `git_worktree_base_path` when configured
 - `git_branch_create_and_switch` to create a local branch from an explicit or detected upstream base and switch to it; it rejects requested branch names that do not match the configured allowed branch patterns
 - `git_branch_switch` to switch to an existing local branch when the worktree is clean; it does not create branches or allow detached checkouts
@@ -291,7 +295,7 @@ When the global config file is missing, runtime tools remain registered. They ca
 
 Some operations resolve defaults at runtime instead of requiring everything to be pinned in config.
 
-- `git_fetch`, `git_sync_base`, `git_push`, `git_worktree_add`, `git_branch_create_and_switch`, and `gh_pr_create_draft` resolve the remote by preferring configured `default_remote`, then the current branch remote, then `origin`
+- `git_fetch`, `git_sync_base`, `git_pull_current_branch`, `git_push`, `git_worktree_add`, `git_branch_create_and_switch`, and `gh_pr_create_draft` resolve the remote by preferring configured `default_remote`, then the current branch remote, then `origin`
 - `git_fetch`, `git_worktree_add`, `git_branch_create_and_switch`, and `gh_pr_create_draft` accept an explicit branch or base input
 - `git_fetch`, `git_sync_base`, `git_worktree_add`, `git_branch_create_and_switch`, and `gh_pr_create_draft` resolve their default branch or base by preferring the remote HEAD branch and falling back to the GitHub repository default branch when no explicit input is provided
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -68,6 +68,7 @@ At minimum, mutating operations include:
 - `git_add`
 - `git_commit`
 - `git_sync_base`
+- `git_pull_current_branch`
 - `git_push`
 - `gh_pr_create_draft`
 
@@ -120,6 +121,7 @@ The server may expose structured tools for operations such as:
 - repository inspection and policy inspection
 - constrained staging and commit creation
 - constrained base-branch synchronization into the current allowed branch
+- constrained current-branch synchronization into the current allowed branch
 - constrained branch creation and branch switching
 - constrained linked worktree creation
 - constrained remote synchronization

--- a/docs/superpowers/plans/2026-04-22-pr-branch-pull.md
+++ b/docs/superpowers/plans/2026-04-22-pr-branch-pull.md
@@ -1,0 +1,65 @@
+# PR Branch Pull Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a constrained MCP tool that lets Codex pull updates from the current branch's remote PR branch.
+
+**Architecture:** Reuse the existing branch authorization, remote resolution, fetch, merge, dirty-worktree, and merge-abort patterns from `git_sync_base`. The new tool fetches only the current branch from the resolved remote and merges only that remote-tracking ref.
+
+**Tech Stack:** TypeScript, MCP SDK, Vitest, Git CLI wrappers.
+
+---
+
+### Task 1: Failing Coverage
+
+**Files:**
+- Create: `tests/gitPullCurrentBranch.test.ts`
+- Modify: `tests/server.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+Add tests for successful remote branch pull, dirty worktree rejection, conflict abort, server tool registration, and tool annotations.
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run: `npm test -- tests/gitPullCurrentBranch.test.ts tests/server.test.ts`
+
+Expected: FAIL because `src/tools/gitPullCurrentBranch.ts` and server registration do not exist yet.
+
+### Task 2: Tool Implementation
+
+**Files:**
+- Create: `src/tools/gitPullCurrentBranch.ts`
+- Modify: `src/errors.ts`
+- Modify: `src/server.ts`
+
+- [ ] **Step 1: Implement the tool**
+
+Add `gitPullCurrentBranch(repo)` with this flow: require allowed current branch, require clean worktree, resolve remote, fetch current branch, merge `refs/remotes/<remote>/<branch>`, abort on conflict, and return `{ branch, remote, remoteRef }`.
+
+- [ ] **Step 2: Register the tool**
+
+Expose `git_pull_current_branch` in `getRegisteredToolNames()` and `createServer()` with a destructive closed-world annotation.
+
+- [ ] **Step 3: Verify green**
+
+Run: `npm test -- tests/gitPullCurrentBranch.test.ts tests/server.test.ts`
+
+Expected: PASS.
+
+### Task 3: Docs and Full Verification
+
+**Files:**
+- Modify: `README.md`
+- Modify: `SPEC.md`
+- Modify: `IMPLEMENTATION.md`
+
+- [ ] **Step 1: Document the tool surface**
+
+Add `git_pull_current_branch` wherever the current tool list and remote/default behavior are documented.
+
+- [ ] **Step 2: Run full verification**
+
+Run: `npm test`, `npm run typecheck`, and `npm run build`.
+
+Expected: all commands pass.

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -116,6 +116,15 @@ export class GitSyncBaseConflictError extends Error {
   }
 }
 
+export class GitPullCurrentBranchConflictError extends Error {
+  constructor(repoPath: string, branch: string, remoteRef: string) {
+    super(
+      `could not pull branch '${branch}' in repository '${repoPath}' from '${remoteRef}' because the merge conflicted`,
+    );
+    this.name = "GitPullCurrentBranchConflictError";
+  }
+}
+
 export class BranchNotFoundError extends Error {
   constructor(branch: string, repoPath: string) {
     super(`branch '${branch}' does not exist in repository '${repoPath}'`);

--- a/src/server.ts
+++ b/src/server.ts
@@ -13,6 +13,7 @@ import { gitBranchSwitch } from "./tools/gitBranchSwitch.js";
 import { ghPrCreateDraft } from "./tools/ghPrCreateDraft.js";
 import { gitCommit } from "./tools/gitCommit.js";
 import { gitFetch } from "./tools/gitFetch.js";
+import { gitPullCurrentBranch } from "./tools/gitPullCurrentBranch.js";
 import { gitPush } from "./tools/gitPush.js";
 import { getGitRepoPolicy } from "./tools/gitRepoPolicy.js";
 import { getGitStatus } from "./tools/gitStatus.js";
@@ -60,6 +61,7 @@ export function getRegisteredToolNames(): string[] {
     "git_branch_switch",
     "git_fetch",
     "git_sync_base",
+    "git_pull_current_branch",
     "git_worktree_add",
     "git_push",
     "gh_pr_create_draft",
@@ -313,6 +315,28 @@ export function createServer(configPath: string): McpServer {
     async ({ repo_path }) => {
       const repo = await resolveRuntimeRepo(configPath, repo_path);
       const result = await gitSyncBase(repo);
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(result, null, 2),
+          },
+        ],
+      };
+    },
+  );
+
+  server.tool(
+    "git_pull_current_branch",
+    "Fetch and merge the current branch from the detected remote into the current allowed branch for an authorized repository. This tool requires a clean worktree, does not accept arbitrary refs or merge flags, and aborts on conflict before returning an error.",
+    {
+      repo_path: z.string().min(1),
+    },
+    CLOSED_WORLD_POTENTIALLY_DESTRUCTIVE_MUTATION_TOOL,
+    async ({ repo_path }) => {
+      const repo = await resolveRuntimeRepo(configPath, repo_path);
+      const result = await gitPullCurrentBranch(repo);
 
       return {
         content: [

--- a/src/tools/gitPullCurrentBranch.ts
+++ b/src/tools/gitPullCurrentBranch.ts
@@ -1,0 +1,53 @@
+import { requireAllowedBranch } from "../auth/branchAuth.js";
+import { CommandExecutionError, DirtyWorktreeError, GitPullCurrentBranchConflictError } from "../errors.js";
+import { abortMerge, fetchBranch, hasMergeInProgress, mergeRefIntoCurrentBranch } from "../exec/git.js";
+import type { RepoPolicy } from "../types/config.js";
+import { getGitStatus } from "./gitStatus.js";
+import { resolveRepoRemote } from "./runtimeDefaults.js";
+
+export type GitPullCurrentBranchResult = {
+  branch: string;
+  remote: string;
+  remoteRef: string;
+};
+
+export async function gitPullCurrentBranch(repo: RepoPolicy): Promise<GitPullCurrentBranchResult> {
+  const branch = await requireAllowedBranch(repo);
+  const status = await getGitStatus(repo);
+  if (!status.isClean) {
+    throw new DirtyWorktreeError(repo.worktreePath);
+  }
+
+  const remote = await resolveRepoRemote(repo);
+  await fetchBranch(repo.worktreePath, remote, branch);
+  const remoteRef = `refs/remotes/${remote}/${branch}`;
+
+  try {
+    await mergeRefIntoCurrentBranch(repo.worktreePath, remoteRef);
+  } catch (error) {
+    if (error instanceof CommandExecutionError) {
+      await abortMergeIfNeeded(repo.worktreePath);
+      throw new GitPullCurrentBranchConflictError(repo.worktreePath, branch, remoteRef);
+    }
+
+    throw error;
+  }
+
+  return {
+    branch,
+    remote,
+    remoteRef,
+  };
+}
+
+async function abortMergeIfNeeded(cwd: string): Promise<void> {
+  if (!(await hasMergeInProgress(cwd))) {
+    return;
+  }
+
+  try {
+    await abortMerge(cwd);
+  } catch {
+    // Best effort cleanup: callers should never be left in a merge flow when abort works.
+  }
+}

--- a/tests/gitPullCurrentBranch.test.ts
+++ b/tests/gitPullCurrentBranch.test.ts
@@ -1,0 +1,141 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { DirtyWorktreeError, GitPullCurrentBranchConflictError } from "../src/errors.js";
+import { hasMergeInProgress } from "../src/exec/git.js";
+import { runCommand } from "../src/exec/run.js";
+import { gitAdd } from "../src/tools/gitAdd.js";
+import { gitBranchCreateAndSwitch } from "../src/tools/gitBranchCreateAndSwitch.js";
+import { gitCommit } from "../src/tools/gitCommit.js";
+import { gitPullCurrentBranch } from "../src/tools/gitPullCurrentBranch.js";
+import { gitPush } from "../src/tools/gitPush.js";
+import { configureTestGitRepo, createTempBareGitRepo, createTempGitRepo } from "./helpers.js";
+
+const tempPaths: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempPaths.splice(0).map((tempPath) => fs.rm(tempPath, { force: true, recursive: true })));
+});
+
+describe("gitPullCurrentBranch", () => {
+  it("fetches and merges the current branch from the resolved remote", async () => {
+    const { repoDir, repo } = await createTempGitRepo();
+    const remoteDir = await createTempBareGitRepo();
+    const updaterDir = await fs.mkdtemp(path.join(path.dirname(repoDir), "git-mcp-pull-updater-"));
+    tempPaths.push(repoDir, remoteDir, updaterDir);
+
+    await runCommand({ cwd: repoDir, command: "git", argv: ["remote", "add", "origin", remoteDir] });
+    await fs.writeFile(path.join(repoDir, "README.md"), "hello\n", "utf8");
+    await gitAdd(repo, ["README.md"]);
+    await gitCommit(repo, "add readme");
+    await gitPush(repo, "main");
+    await runCommand({ cwd: remoteDir, command: "git", argv: ["symbolic-ref", "HEAD", "refs/heads/main"] });
+
+    await gitBranchCreateAndSwitch(
+      {
+        ...repo,
+        allowedBranchPatterns: [/^feature\/.+$/],
+      },
+      { newBranch: "feature/pr-branch" },
+    );
+    const featureRepo = {
+      ...repo,
+      worktreePath: repoDir,
+      allowedBranchPatterns: [/^feature\/.+$/],
+    };
+    await fs.writeFile(path.join(repoDir, "FEATURE.md"), "local feature\n", "utf8");
+    await gitAdd(featureRepo, ["FEATURE.md"]);
+    await gitCommit(featureRepo, "add feature");
+    await gitPush(featureRepo, "feature/pr-branch");
+
+    await runCommand({ cwd: updaterDir, command: "git", argv: ["clone", remoteDir, "."] });
+    await configureTestGitRepo(updaterDir);
+    await runCommand({ cwd: updaterDir, command: "git", argv: ["checkout", "feature/pr-branch"] });
+    await fs.writeFile(path.join(updaterDir, "REMOTE.md"), "remote update\n", "utf8");
+    await runCommand({ cwd: updaterDir, command: "git", argv: ["add", "REMOTE.md"] });
+    await runCommand({ cwd: updaterDir, command: "git", argv: ["commit", "-m", "remote feature update"] });
+    await runCommand({ cwd: updaterDir, command: "git", argv: ["push", "origin", "HEAD:refs/heads/feature/pr-branch"] });
+
+    const result = await gitPullCurrentBranch(featureRepo);
+    const remoteFile = await fs.readFile(path.join(repoDir, "REMOTE.md"), "utf8");
+    const headOid = await runCommand({
+      cwd: repoDir,
+      command: "git",
+      argv: ["rev-parse", "--verify", "HEAD"],
+    });
+    const remoteBranchOid = await runCommand({
+      cwd: repoDir,
+      command: "git",
+      argv: ["rev-parse", "--verify", "refs/remotes/origin/feature/pr-branch"],
+    });
+
+    expect(result).toEqual({
+      branch: "feature/pr-branch",
+      remote: "origin",
+      remoteRef: "refs/remotes/origin/feature/pr-branch",
+    });
+    expect(remoteFile).toBe("remote update\n");
+    expect(headOid.stdout.trim()).toBe(remoteBranchOid.stdout.trim());
+  });
+
+  it("rejects dirty worktrees before pulling", async () => {
+    const { repoDir, repo } = await createTempGitRepo();
+    tempPaths.push(repoDir);
+
+    await fs.writeFile(path.join(repoDir, "README.md"), "dirty\n", "utf8");
+
+    await expect(gitPullCurrentBranch(repo)).rejects.toBeInstanceOf(DirtyWorktreeError);
+  });
+
+  it("aborts the merge and raises a conflict error when the pull conflicts", async () => {
+    const { repoDir, repo } = await createTempGitRepo();
+    const remoteDir = await createTempBareGitRepo();
+    const updaterDir = await fs.mkdtemp(path.join(path.dirname(repoDir), "git-mcp-pull-conflict-updater-"));
+    tempPaths.push(repoDir, remoteDir, updaterDir);
+
+    await runCommand({ cwd: repoDir, command: "git", argv: ["remote", "add", "origin", remoteDir] });
+    await fs.writeFile(path.join(repoDir, "README.md"), "base\n", "utf8");
+    await gitAdd(repo, ["README.md"]);
+    await gitCommit(repo, "initial base");
+    await gitPush(repo, "main");
+    await runCommand({ cwd: remoteDir, command: "git", argv: ["symbolic-ref", "HEAD", "refs/heads/main"] });
+
+    await gitBranchCreateAndSwitch(
+      {
+        ...repo,
+        allowedBranchPatterns: [/^feature\/.+$/],
+      },
+      { newBranch: "feature/conflict-pull" },
+    );
+    const featureRepo = {
+      ...repo,
+      worktreePath: repoDir,
+      allowedBranchPatterns: [/^feature\/.+$/],
+    };
+    await gitPush(featureRepo, "feature/conflict-pull");
+    await fs.writeFile(path.join(repoDir, "README.md"), "local change\n", "utf8");
+    await gitAdd(featureRepo, ["README.md"]);
+    await gitCommit(featureRepo, "local update");
+
+    await runCommand({ cwd: updaterDir, command: "git", argv: ["clone", remoteDir, "."] });
+    await configureTestGitRepo(updaterDir);
+    await runCommand({ cwd: updaterDir, command: "git", argv: ["checkout", "feature/conflict-pull"] });
+    await fs.writeFile(path.join(updaterDir, "README.md"), "remote change\n", "utf8");
+    await runCommand({ cwd: updaterDir, command: "git", argv: ["add", "README.md"] });
+    await runCommand({ cwd: updaterDir, command: "git", argv: ["commit", "-m", "remote conflicting update"] });
+    await runCommand({ cwd: updaterDir, command: "git", argv: ["push", "origin", "HEAD:refs/heads/feature/conflict-pull"] });
+
+    await expect(gitPullCurrentBranch(featureRepo)).rejects.toBeInstanceOf(GitPullCurrentBranchConflictError);
+    await expect(hasMergeInProgress(repoDir)).resolves.toBe(false);
+
+    const status = await runCommand({
+      cwd: repoDir,
+      command: "git",
+      argv: ["status", "--short"],
+    });
+
+    expect(status.stdout.trim()).toBe("");
+  });
+});

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -26,6 +26,7 @@ describe("getRegisteredToolNames", () => {
       "git_branch_switch",
       "git_fetch",
       "git_sync_base",
+      "git_pull_current_branch",
       "git_worktree_add",
       "git_push",
       "gh_pr_create_draft",
@@ -90,6 +91,11 @@ describe("createServer", () => {
         openWorldHint: false,
       },
       git_sync_base: {
+        readOnlyHint: false,
+        destructiveHint: true,
+        openWorldHint: false,
+      },
+      git_pull_current_branch: {
         readOnlyHint: false,
         destructiveHint: true,
         openWorldHint: false,


### PR DESCRIPTION
## Why

Codex can fetch remote branch updates through `git_fetch`, but it has not had a constrained MCP operation for the common PR workflow where the current remote PR branch has moved and the local branch needs to incorporate those commits. That gap pushed agents toward inspecting diffs or asking for shell Git operations because the server exposed `git_sync_base` for base-branch merges but no equivalent for the current branch's remote tracking ref.

This change adds `git_pull_current_branch`, which keeps the behavior narrow: it validates the current branch against policy, requires a clean worktree, fetches only the current branch from the resolved remote, and merges only `refs/remotes/<remote>/<current-branch>`. Conflicts are aborted before returning an error, matching the existing `git_sync_base` safety pattern.

Closes #70

## Impact

The expected improvement is that Codex can safely bring remote PR branch commits into an authorized local branch without a generic pull, merge, or refspec interface. The main risk is normal merge-conflict behavior: if the remote branch diverges in a conflicting way, the tool will abort the merge and return a dedicated conflict error instead of leaving the repository in a merge flow.