### PR TITLE
Allow empty global repo entries with repo-local policy

### DIFF
--- a/src/auth/repoAuth.ts
+++ b/src/auth/repoAuth.ts
@@ -2,7 +2,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 
 import { loadRepoLocalPolicy } from "../config.js";
-import { RepoNotAllowedError } from "../errors.js";
+import { ConfigError, RepoNotAllowedError } from "../errors.js";
 import { getGitCommonDir, getGitTopLevel } from "../exec/git.js";
 import type { Config, RepoPolicy } from "../types/config.js";
 
@@ -23,6 +23,12 @@ export async function resolveAllowedRepo(config: Config, repoPath: string): Prom
   }
 
   if (repo) {
+    if (repo.allowedBranchPatterns.length === 0) {
+      throw new ConfigError(
+        `repository '${repo.path}' must define allowed_branch_patterns directly or inherit them from top-level defaults`,
+      );
+    }
+
     return {
       ...repo,
       worktreePath: resolvedRepo.topLevel,

--- a/src/config.ts
+++ b/src/config.ts
@@ -212,13 +212,6 @@ async function normalizeConfig(config: EditableConfig): Promise<Config> {
     const gitWorktreeBasePath = explicitGitWorktreeBasePath ?? defaultGitWorktreeBasePath;
 
     const patternSources = repo.allowed_branch_patterns ?? config.defaults?.allowed_branch_patterns ?? [];
-
-    if (patternSources.length === 0) {
-      throw new ConfigError(
-        `repository '${repo.path}' must define allowed_branch_patterns directly or inherit them from top-level defaults`,
-      );
-    }
-
     const allowedBranchPatterns = compileBranchPatterns(patternSources, repo.path);
     const workflowMode = repo.workflow_mode ?? config.defaults?.workflow_mode;
     const repoOverrides = buildRepoOverrides({

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -298,16 +298,18 @@ describe("loadConfig", () => {
     expect(config.repositories[0]?.workflowMode).toBe("feature_branch");
   });
 
-  it("rejects repositories without effective branch patterns", async () => {
+  it("allows repository entries without effective branch patterns during config load", async () => {
     const repoDir = await fs.mkdtemp(path.join(os.tmpdir(), "git-mcp-no-patterns-repo-"));
     const configPath = path.join(os.tmpdir(), `git-mcp-config-${Date.now()}-no-patterns.yaml`);
     tempPaths.push(repoDir, configPath);
 
     await fs.writeFile(configPath, `repositories:\n  - path: ${repoDir}\n`, "utf8");
 
-    await expect(loadConfig(configPath)).rejects.toThrow(
-      `repository '${repoDir}' must define allowed_branch_patterns directly or inherit them from top-level defaults`,
-    );
+    const config = await loadConfig(configPath);
+
+    expect(config.repositories).toHaveLength(1);
+    expect(config.repositories[0]?.allowedBranchPatterns).toEqual([]);
+    expect(config.repositories[0]?.repoOverrides).toBeUndefined();
   });
 
   it("expands home-directory paths", async () => {

--- a/tests/repoAuth.test.ts
+++ b/tests/repoAuth.test.ts
@@ -196,6 +196,54 @@ describe("resolveAllowedRepo", () => {
     expect(resolvedRepo.repoOverridesApplied).toBe(false);
   });
 
+  it("allows empty global repo entries when repo-local policy provides branch patterns", async () => {
+    const { repoDir } = await createTempGitRepo();
+    tempPaths.push(repoDir);
+    const canonicalRepoDir = await fs.realpath(repoDir);
+
+    await fs.writeFile(
+      path.join(repoDir, ".git-unleash.yaml"),
+      [
+        "allowed_branch_patterns:",
+        '  - "^owner/.+$"',
+        'feature_branch_pattern: "owner/<feature-name>"',
+      ].join("\n"),
+      "utf8",
+    );
+
+    const configPath = path.join(os.tmpdir(), `git-mcp-config-${Date.now()}-empty-global-repo.yaml`);
+    tempPaths.push(configPath);
+
+    await fs.writeFile(configPath, `repositories:\n  - path: ${repoDir}\n`, "utf8");
+
+    const config = await loadConfig(configPath);
+    const resolvedRepo = await resolveAllowedRepo(config, repoDir);
+
+    expect(resolvedRepo.policySource).toBe("repo_local");
+    expect(resolvedRepo.canonicalPath).toBe(canonicalRepoDir);
+    expect(resolvedRepo.allowedBranchPatterns.map((pattern) => pattern.source)).toEqual(["^owner\\/.+$"]);
+    expect(resolvedRepo.featureBranchPattern).toBe("owner/<feature-name>");
+    expect(resolvedRepo.repoOverridesApplied).toBe(false);
+  });
+
+  it("rejects empty global repo entries when no repo-local policy provides branch patterns", async () => {
+    const { repoDir } = await createTempGitRepo();
+    tempPaths.push(repoDir);
+
+    const configPath = path.join(os.tmpdir(), `git-mcp-config-${Date.now()}-empty-global-no-local.yaml`);
+    tempPaths.push(configPath);
+
+    await fs.writeFile(configPath, `repositories:\n  - path: ${repoDir}\n`, "utf8");
+
+    const config = await loadConfig(configPath);
+
+    await expect(resolveAllowedRepo(config, repoDir)).rejects.toEqual(
+      new ConfigError(
+        `repository '${repoDir}' must define allowed_branch_patterns directly or inherit them from top-level defaults`,
+      ),
+    );
+  });
+
   it("rejects repo-local config that sets default_remote", async () => {
     const { repoDir } = await createTempGitRepo();
     tempPaths.push(repoDir);


### PR DESCRIPTION
## Why

A global repository entry that only names a path was rejected during config load because `normalizeConfig` required effective `allowed_branch_patterns` immediately. That prevented repository resolution from loading a valid repo-local `.git-unleash.yaml`, even though repo-local policy is intended to provide the base policy and global entries act as field-by-field overrides.

Closes #72

## What changed

- Allow patternless global repository entries to normalize with an empty branch pattern list.
- Preserve the existing missing-pattern error during repository resolution when no repo-local policy supplies branch patterns.
- Add regression coverage for both the repo-local success path and the global-only rejection path.

## Impact

Repositories with valid repo-local policy can now be listed globally without duplicating branch patterns. Global-only entries without effective branch patterns still fail before branch authorization can proceed.

## Validation

- `npm run build`
- `npm test`