### PR TITLE
mcp: mark git_fetch and git_push as additive

### DIFF
--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -346,7 +346,7 @@ Execution:
 
 - push only the current branch
 - resolve the remote from configuration or constrained runtime defaults
-- do not allow arbitrary refspecs
+- do not allow arbitrary refspecs, force-like behavior, delete pushes, or unrelated branch pushes
 
 Output guidance:
 

--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ Once registered, Codex should be able to use:
 - `git_worktree_add` to create a linked worktree for a new allowed branch at an explicit absolute path; it fetches the explicit or detected base branch first, does not allow arbitrary refs, and enforces `git_worktree_base_path` when configured
 - `git_branch_create_and_switch` to create a local branch from an explicit or detected upstream base and switch to it; it rejects requested branch names that do not match the configured allowed branch patterns
 - `git_branch_switch` to switch to an existing local branch when the worktree is clean; it does not create branches or allow detached checkouts
-- `git_push` to push the current branch to the detected remote; it only pushes `HEAD` to `refs/heads/<current-branch>` and does not allow arbitrary refspecs or force-like behavior
+- `git_push` to push the current branch to the detected remote; it only pushes `HEAD` to `refs/heads/<current-branch>` and does not allow arbitrary refspecs, force-like behavior, delete pushes, or unrelated branch pushes
 - `gh_pr_create_draft` to create a draft PR for the current branch using an explicit base or the detected default branch; it is draft-only and requires a non-empty title
 
 Mutating tools reject detached HEAD.

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Notes:
 - each repository must end up with at least one effective allowed branch pattern, either from the repo entry or inherited `defaults`
 - `git_repo_policy` returns the configured branch patterns and related repository defaults for an authorized repository, including `feature_branch_pattern`, `git_worktree_base_path`, `workflow_mode`, the policy source, whether repo overrides were applied, and the repo-local config path when applicable
 - `git_add`, `git_commit`, `git_sync_base`, `git_pull_current_branch`, `git_push`, and `gh_pr_create_draft` require the current branch to match one of the configured patterns
-- `git_fetch` only requires the repository to be authorized, fetches from the resolved remote, and uses an explicit branch when provided or the detected base branch otherwise
+- `git_fetch` only requires the repository to be authorized, fetches from the resolved remote, updates local fetch metadata and remote-tracking state only, and uses an explicit branch when provided or the detected base branch otherwise
 - `git_sync_base` requires a clean worktree, fetches the detected remote base branch, merges only that remote-tracking ref into the current allowed branch, and aborts the merge before returning an error if a conflict occurs
 - `git_pull_current_branch` requires a clean worktree, fetches the current branch from the resolved remote, merges only that remote-tracking ref into the current allowed branch, and aborts the merge before returning an error if a conflict occurs
 - `git_worktree_add` requires an explicit absolute target path, validates the requested new branch name against `allowed_branch_patterns`, creates a linked worktree from an explicit or detected upstream base branch, and is only allowed when `workflow_mode` is unset or `worktree`
@@ -278,7 +278,7 @@ Once registered, Codex should be able to use:
 - `git_status` for an authorized repository
 - `git_add` for repository-relative paths inside an authorized repository; it rejects absolute paths and repository-escaping paths like `../x`
 - `git_commit` with a normal commit message on an allowed branch; it rejects empty commit messages and empty commits
-- `git_fetch` to fetch a plain branch name from the detected remote; it does not allow arbitrary fetch arguments or refspecs and uses an explicit branch when provided or the detected base branch otherwise
+- `git_fetch` to fetch a plain branch name from the detected remote; it updates local fetch metadata and remote-tracking state only, does not allow arbitrary fetch arguments or refspecs, and uses an explicit branch when provided or the detected base branch otherwise
 - `git_sync_base` to merge the detected remote base branch into the current allowed branch; it requires a clean worktree, does not allow arbitrary refs or merge flags, and aborts on conflict before returning an error
 - `git_pull_current_branch` to fetch and merge the current branch from the detected remote into the current allowed branch; it requires a clean worktree, does not allow arbitrary refs or merge flags, and aborts on conflict before returning an error
 - `git_worktree_add` to create a linked worktree for a new allowed branch at an explicit absolute path; it fetches the explicit or detected base branch first, does not allow arbitrary refs, and enforces `git_worktree_base_path` when configured

--- a/src/server.ts
+++ b/src/server.ts
@@ -284,12 +284,12 @@ export function createServer(configPath: string): McpServer {
 
   server.tool(
     "git_fetch",
-    "Fetch a plain branch name from the detected remote for an authorized repository. This tool refreshes remote-tracking refs, accepts an explicit branch when provided, otherwise detects the repository base branch at runtime, and does not allow arbitrary fetch arguments or refspecs.",
+    "Fetch a plain branch name from the detected remote for an authorized repository. This tool updates local fetch metadata and remote-tracking state only; it does not modify the working tree, index, current branch, or remote repository, and does not allow arbitrary fetch arguments or refspecs.",
     {
       repo_path: z.string().min(1),
       branch: z.string().optional(),
     },
-    CLOSED_WORLD_POTENTIALLY_DESTRUCTIVE_MUTATION_TOOL,
+    CLOSED_WORLD_ADDITIVE_MUTATION_TOOL,
     async ({ repo_path, branch }) => {
       const repo = await resolveRuntimeRepo(configPath, repo_path);
       const result = await gitFetch(repo, { branch });

--- a/src/server.ts
+++ b/src/server.ts
@@ -376,11 +376,11 @@ export function createServer(configPath: string): McpServer {
 
   server.tool(
     "git_push",
-    "Push the current branch to the detected remote for an authorized repository. This tool mutates repository state, requires the current branch to match configured full-match patterns, and does not allow arbitrary refspecs, force-like behavior, or pushing unrelated branches.",
+    "Push the current branch to the detected remote for an authorized repository. This tool requires the current branch to match configured full-match patterns, pushes only HEAD to refs/heads/<current-branch>, and does not allow arbitrary refspecs, force-like behavior, delete pushes, or pushing unrelated branches.",
     {
       repo_path: z.string().min(1),
     },
-    CLOSED_WORLD_POTENTIALLY_DESTRUCTIVE_MUTATION_TOOL,
+    CLOSED_WORLD_ADDITIVE_MUTATION_TOOL,
     async ({ repo_path }) => {
       const repo = await resolveRuntimeRepo(configPath, repo_path);
       const branch = await requireAllowedBranch(repo);

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -107,7 +107,7 @@ describe("createServer", () => {
       },
       git_push: {
         readOnlyHint: false,
-        destructiveHint: true,
+        destructiveHint: false,
         openWorldHint: false,
       },
       gh_pr_create_draft: {

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -87,7 +87,7 @@ describe("createServer", () => {
       },
       git_fetch: {
         readOnlyHint: false,
-        destructiveHint: true,
+        destructiveHint: false,
         openWorldHint: false,
       },
       git_sync_base: {


### PR DESCRIPTION
## Why

`git_fetch` and `git_push` are constrained operations in this MCP server, but their previous annotations treated them as potentially destructive. That made the tool metadata more conservative than the actual contracts and could contribute to avoidable client friction.

`git_fetch` only updates local fetch metadata and remote-tracking state. `git_push` only pushes `HEAD` to `refs/heads/<current-branch>` for an allowed current branch, and it rejects arbitrary refspecs, force-like behavior, delete pushes, and unrelated branch pushes. Marking both tools as additive makes the MCP annotations line up with those constraints while leaving higher-risk local state changes classified cautiously.

## Impact

Codex clients get a more accurate `destructiveHint: false` signal for constrained fetch and push operations. The expected benefit is fewer unnecessary approval prompts for operations this server already limits tightly.

The main risk is that clients may treat push as lower-friction even though it still mutates remote repository state and can trigger CI or notifications. The server-side restrictions remain in place, and `git_sync_base`, `git_pull_current_branch`, and `git_branch_switch` still keep their destructive annotations.

## Verification

- `npx vitest run tests/server.test.ts`
- `npm test`
- `npm run typecheck`