### PR TITLE
Split workflow preference from setup authorization

### DIFF
--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -363,6 +363,7 @@ Validation:
 - `new_branch` must be non-empty after trimming
 - `new_branch` must match at least one configured allowed branch pattern
 - `new_branch` must not already exist locally
+- effective allowed workflow modes must include `worktree`
 - resolve the remote by preferring configured `default_remote`, then the current branch remote, then `origin`
 - if `branch` is provided, treat it as the upstream base branch name
 - otherwise resolve the base branch from remote HEAD first, with GitHub default-branch lookup as a fallback
@@ -387,6 +388,7 @@ Validation:
 - `new_branch` must be non-empty after trimming
 - `new_branch` must match at least one configured allowed branch pattern
 - `new_branch` must not already exist
+- effective allowed workflow modes must include `feature_branch`
 - resolve the remote by preferring configured `default_remote`, then the current branch remote, then `origin`
 - if `branch` is provided, treat it as the upstream base branch name
 - otherwise resolve the base branch from remote HEAD first, with GitHub default-branch lookup as a fallback
@@ -407,7 +409,7 @@ Validation:
 
 - repository path is required
 - repository must be allowlisted
-- `workflow_mode` must be unset or `feature_branch`
+- effective allowed workflow modes must include `feature_branch`
 - worktree must be clean
 - `branch` must be non-empty after trimming
 - `branch` must match the configured allowed branch patterns

--- a/README.md
+++ b/README.md
@@ -93,8 +93,9 @@ Notes:
 - `allowed_branch_patterns` and `feature_branch_pattern` support a dedicated `<user>` placeholder, resolved from `USER`, then `USERNAME`, then the system account username; other environment-variable expansion is intentionally not supported
 - `git_worktree_base_path` is inherited or overridden per repository and, when configured, constrains `git_worktree_add.path` to stay under that base
 - for Codex workflows, prefer a repo-specific in-repository worktree base such as `.worktrees/` when you want linked worktrees to stay under the same trusted project root; add that directory to `.gitignore`
-- `workflow_mode` is optional preference metadata for agents; supported values are `worktree`, `feature_branch`, and `current_branch`
+- `workflow_mode` is optional preference metadata for agents; it tells them which Git setup path to try first for this repository. Supported values are `worktree`, `feature_branch`, and `current_branch`
 - `allowed_workflow_modes` is the explicit authorization boundary for setup tools and accepts `worktree`, `feature_branch`, or `current_branch`
+- when both fields are present, agents should treat `workflow_mode` as the preferred starting flow and `allowed_workflow_modes` as the list of setup flows they may actually use
 - when `allowed_workflow_modes` is omitted but `workflow_mode` is set, setup tools derive the allowed mode from `workflow_mode` for backward compatibility
 - when both `allowed_workflow_modes` and `workflow_mode` are omitted, setup tools fail closed and ask the caller to inspect `git_repo_policy`
 - `current_branch` cannot be combined with `feature_branch` or `worktree` in `allowed_workflow_modes`
@@ -105,7 +106,7 @@ Notes:
 - branch patterns are full-match regexes against the current branch name
 - keep branch patterns simple: advanced group syntax, backreferences, and nested quantifiers are rejected at config load time
 - each repository must end up with at least one effective allowed branch pattern, either from the repo entry or inherited `defaults`
-- `git_repo_policy` returns the configured branch patterns and related repository defaults for an authorized repository, including `feature_branch_pattern`, `git_worktree_base_path`, `workflow_mode`, `allowed_workflow_modes`, the policy source, whether repo overrides were applied, and the repo-local config path when applicable
+- `git_repo_policy` returns the configured branch patterns and related repository defaults for an authorized repository, including `feature_branch_pattern`, `git_worktree_base_path`, the preferred `workflow_mode`, `allowed_workflow_modes`, the policy source, whether repo overrides were applied, and the repo-local config path when applicable
 - `git_add`, `git_commit`, `git_sync_base`, `git_pull_current_branch`, `git_push`, and `gh_pr_create_draft` require the current branch to match one of the configured patterns
 - `git_fetch` only requires the repository to be authorized, fetches from the resolved remote, updates local fetch metadata and remote-tracking state only, and uses an explicit branch when provided or the detected base branch otherwise
 - `git_sync_base` requires a clean worktree, fetches the detected remote base branch, merges only that remote-tracking ref into the current allowed branch, and aborts the merge before returning an error if a conflict occurs
@@ -194,15 +195,16 @@ The intended happy path is:
 2. Call `config_upsert_repo` to add or update an allowlisted repository entry when needed.
 3. Or check in `.git-unleash.yaml` to authorize the repository through repo-local policy instead of the global YAML.
 4. Call `git_repo_policy` or `git_status` to inspect the authorized repository.
-5. Before creating a branch, use `git_repo_policy` to confirm the configured `allowed_branch_patterns`, then choose a new branch name that matches that policy.
-6. Call `git_branch_create_and_switch` to branch from an explicit or detected upstream base when you need a new local branch in the current worktree.
-7. Call `git_worktree_add` when you need a separate linked worktree on a new allowed branch at an explicit absolute path.
-8. Call `git_sync_base` when you need to bring the detected remote base branch into the current allowed branch without exposing generic merge controls.
-9. Call `git_pull_current_branch` when you need to bring the current branch's resolved remote branch into the current allowed branch without exposing generic merge controls.
-10. Call `git_add` with explicit repository-relative paths.
-11. Call `git_commit` with a normal commit message.
-12. Call `git_push` to push the current branch to the resolved remote.
-13. Call `gh_pr_create_draft` to open a draft PR against an explicit base or the detected default base branch.
+5. Prefer the setup flow advertised by `git_repo_policy.workflow_mode` as the way to start work in that repository.
+6. Before creating a branch, use `git_repo_policy` to confirm the configured `allowed_branch_patterns`, then choose a new branch name that matches that policy.
+7. Call `git_branch_create_and_switch` when the preferred or selected setup flow is `feature_branch` and you need a new local branch in the current worktree.
+8. Call `git_worktree_add` when the preferred or selected setup flow is `worktree` and you need a separate linked worktree on a new allowed branch at an explicit absolute path.
+9. Call `git_sync_base` when you need to bring the detected remote base branch into the current allowed branch without exposing generic merge controls.
+10. Call `git_pull_current_branch` when you need to bring the current branch's resolved remote branch into the current allowed branch without exposing generic merge controls.
+11. Call `git_add` with explicit repository-relative paths.
+12. Call `git_commit` with a normal commit message.
+13. Call `git_push` to push the current branch to the resolved remote.
+14. Call `gh_pr_create_draft` to open a draft PR against an explicit base or the detected default base branch.
 
 Each step stays inside a fixed policy boundary. There is no arbitrary checkout, no arbitrary push refspec, no amend flow, and no non-draft PR creation.
 
@@ -339,6 +341,8 @@ repositories:
       - feature_branch
 ```
 
+In that example, `workflow_mode` tells agents to start with the `worktree` setup flow by default, while `allowed_workflow_modes` keeps both `worktree` and `feature_branch` available when the caller needs either one.
+
 If you want some repositories to stay on their base branch instead of creating a worktree or feature branch:
 
 ```yaml
@@ -359,7 +363,7 @@ repositories:
 
 If you want to bootstrap the config and then add this repository incrementally, a minimal progression is:
 
-1. Call `config_bootstrap` with defaults such as `feature_branch_pattern`, `workflow_mode`, or `allowed_workflow_modes`.
-2. Call `config_upsert_repo` with `repo_path`, and optionally `git_worktree_base_path`, `default_remote`, `allowed_branch_patterns`, `workflow_mode`, or `allowed_workflow_modes`.
+1. Call `config_bootstrap` with defaults such as `feature_branch_pattern`, the preferred `workflow_mode`, or `allowed_workflow_modes`.
+2. Call `config_upsert_repo` with `repo_path`, and optionally `git_worktree_base_path`, `default_remote`, `allowed_branch_patterns`, the preferred `workflow_mode`, or `allowed_workflow_modes`.
 3. Use the Git tools against that repository; they will reload the YAML on each call.
 ```

--- a/README.md
+++ b/README.md
@@ -64,6 +64,9 @@ defaults:
   git_worktree_base_path: /tmp/git-worktrees
   allow_draft_prs: true
   workflow_mode: worktree
+  allowed_workflow_modes:
+    - feature_branch
+    - worktree
 
 repositories:
   - path: ~/projects/codex-git-unleash-mcp
@@ -74,6 +77,8 @@ repositories:
     feature_branch_pattern: "feature/<feature-name>"
     allow_draft_prs: false
     workflow_mode: feature_branch
+    allowed_workflow_modes:
+      - feature_branch
 ```
 
 Notes:
@@ -82,29 +87,34 @@ Notes:
 - `config_bootstrap` creates a minimal valid YAML config file and refuses to overwrite an existing file
 - `config_upsert_repo` adds or updates one repository entry in the YAML config and matches existing entries by canonical repository path
 - config changes are reloaded from disk on the next tool call, so a server restart is not required after `config_bootstrap` or `config_upsert_repo`
-- top-level `defaults` are optional and may define `allowed_branch_patterns`, `feature_branch_pattern`, `git_worktree_base_path`, `default_remote`, `allow_draft_prs`, and `workflow_mode`
+- top-level `defaults` are optional and may define `allowed_branch_patterns`, `feature_branch_pattern`, `git_worktree_base_path`, `default_remote`, `allow_draft_prs`, `workflow_mode`, and `allowed_workflow_modes`
 - repository values override top-level defaults field-by-field
 - `feature_branch_pattern` is an optional suggested naming template for new feature branches; it is advisory metadata and does not grant permission to use a branch name that fails `allowed_branch_patterns`
 - `allowed_branch_patterns` and `feature_branch_pattern` support a dedicated `<user>` placeholder, resolved from `USER`, then `USERNAME`, then the system account username; other environment-variable expansion is intentionally not supported
 - `git_worktree_base_path` is inherited or overridden per repository and, when configured, constrains `git_worktree_add.path` to stay under that base
 - for Codex workflows, prefer a repo-specific in-repository worktree base such as `.worktrees/` when you want linked worktrees to stay under the same trusted project root; add that directory to `.gitignore`
-- `workflow_mode` is optional and enforced for branch-setup tools; supported values are `worktree`, `feature_branch`, and `current_branch`
-- `worktree` means the preferred setup flow is `git_worktree_add`
-- `feature_branch` means the preferred setup flow is `git_branch_create_and_switch`
+- `workflow_mode` is optional preference metadata for agents; supported values are `worktree`, `feature_branch`, and `current_branch`
+- `allowed_workflow_modes` is the explicit authorization boundary for setup tools and accepts `worktree`, `feature_branch`, or `current_branch`
+- when `allowed_workflow_modes` is omitted but `workflow_mode` is set, setup tools derive the allowed mode from `workflow_mode` for backward compatibility
+- when both `allowed_workflow_modes` and `workflow_mode` are omitted, setup tools fail closed and ask the caller to inspect `git_repo_policy`
+- `current_branch` cannot be combined with `feature_branch` or `worktree` in `allowed_workflow_modes`
+- when both fields are set, `workflow_mode` must be included in `allowed_workflow_modes`
+- `worktree` means `git_worktree_add` is authorized
+- `feature_branch` means `git_branch_create_and_switch` and `git_branch_switch` are authorized
 - `current_branch` means do not create a new worktree or feature branch; work directly on the current allowed branch
 - branch patterns are full-match regexes against the current branch name
 - keep branch patterns simple: advanced group syntax, backreferences, and nested quantifiers are rejected at config load time
 - each repository must end up with at least one effective allowed branch pattern, either from the repo entry or inherited `defaults`
-- `git_repo_policy` returns the configured branch patterns and related repository defaults for an authorized repository, including `feature_branch_pattern`, `git_worktree_base_path`, `workflow_mode`, the policy source, whether repo overrides were applied, and the repo-local config path when applicable
+- `git_repo_policy` returns the configured branch patterns and related repository defaults for an authorized repository, including `feature_branch_pattern`, `git_worktree_base_path`, `workflow_mode`, `allowed_workflow_modes`, the policy source, whether repo overrides were applied, and the repo-local config path when applicable
 - `git_add`, `git_commit`, `git_sync_base`, `git_pull_current_branch`, `git_push`, and `gh_pr_create_draft` require the current branch to match one of the configured patterns
 - `git_fetch` only requires the repository to be authorized, fetches from the resolved remote, updates local fetch metadata and remote-tracking state only, and uses an explicit branch when provided or the detected base branch otherwise
 - `git_sync_base` requires a clean worktree, fetches the detected remote base branch, merges only that remote-tracking ref into the current allowed branch, and aborts the merge before returning an error if a conflict occurs
 - `git_pull_current_branch` requires a clean worktree, fetches the current branch from the resolved remote, merges only that remote-tracking ref into the current allowed branch, and aborts the merge before returning an error if a conflict occurs
-- `git_worktree_add` requires an explicit absolute target path, validates the requested new branch name against `allowed_branch_patterns`, creates a linked worktree from an explicit or detected upstream base branch, and is only allowed when `workflow_mode` is unset or `worktree`
+- `git_worktree_add` requires an explicit absolute target path, validates the requested new branch name against `allowed_branch_patterns`, creates a linked worktree from an explicit or detected upstream base branch, and requires `worktree` in the effective allowed workflow modes
 - when `git_worktree_base_path` is configured, `git_worktree_add.path` must resolve under that base path
 - `git_branch_create_and_switch` and `git_branch_switch` require a clean worktree
-- `git_branch_create_and_switch` also requires the requested new branch name to match `allowed_branch_patterns`, and is only allowed when `workflow_mode` is unset or `feature_branch`
-- `git_branch_switch` also requires the requested branch name to match `allowed_branch_patterns`, and is only allowed when `workflow_mode` is unset or `feature_branch`
+- `git_branch_create_and_switch` also requires the requested new branch name to match `allowed_branch_patterns`, and requires `feature_branch` in the effective allowed workflow modes
+- `git_branch_switch` also requires the requested branch name to match `allowed_branch_patterns`, and requires `feature_branch` in the effective allowed workflow modes
 - remote resolution prefers configured `default_remote` when present and valid, then the current branch's remote, then `origin`
 - branch creation and PR base resolution prefer the remote HEAD branch and fall back to GitHub default-branch detection when needed
 - `git_status` only requires the repository to be authorized
@@ -115,6 +125,7 @@ Policy precedence:
 - if the global config has a matching repository entry, that repository entry overrides the repo-local base field-by-field
 - otherwise, top-level `defaults` are the base policy
 - if the global config has a matching repository entry, that repository entry overrides the defaults base field-by-field
+- for backward compatibility, an explicit `workflow_mode` with no `allowed_workflow_modes` also sets the effective allowed workflow modes to that single workflow
 
 ### Repo-Local Policy
 
@@ -128,6 +139,9 @@ allowed_branch_patterns:
 feature_branch_pattern: "<user>/<feature-name>"
 git_worktree_base_path: .worktrees
 workflow_mode: worktree
+allowed_workflow_modes:
+  - feature_branch
+  - worktree
 ```
 
 Repo-local policy rules:
@@ -274,7 +288,7 @@ Once registered, Codex should be able to use:
 
 - `config_bootstrap` to create the initial YAML config file when it does not exist yet; it writes a minimal valid config and the runtime tool handlers will see it on their next call
 - `config_upsert_repo` to add or update one repository entry in the YAML config; it validates the resulting file against the existing schema, matches existing repos by canonical path, and the runtime tool handlers will see the updated policy on their next call
-- `git_repo_policy` to inspect the configured path, canonical path, allowed branch patterns, suggested feature-branch pattern, configured worktree base path, default remote, draft-PR setting, and policy source for an authorized repository
+- `git_repo_policy` to inspect the configured path, canonical path, allowed branch patterns, suggested feature-branch pattern, configured worktree base path, workflow preference, allowed workflow modes, default remote, draft-PR setting, and policy source for an authorized repository
 - `git_status` for an authorized repository
 - `git_add` for repository-relative paths inside an authorized repository; it rejects absolute paths and repository-escaping paths like `../x`
 - `git_commit` with a normal commit message on an allowed branch; it rejects empty commit messages and empty commits
@@ -311,6 +325,9 @@ defaults:
     - "^main$"
   feature_branch_pattern: "<user>/<feature-name>"
   workflow_mode: worktree
+  allowed_workflow_modes:
+    - feature_branch
+    - worktree
 
 repositories:
   - path: ~/projects/codex-git-unleash-mcp
@@ -318,6 +335,8 @@ repositories:
     allowed_branch_patterns:
       - "^feature/[a-z0-9._-]+$"
     workflow_mode: feature_branch
+    allowed_workflow_modes:
+      - feature_branch
 ```
 
 If you want some repositories to stay on their base branch instead of creating a worktree or feature branch:
@@ -326,17 +345,21 @@ If you want some repositories to stay on their base branch instead of creating a
 repositories:
   - path: ~/projects/dm-cv-on-steroids
     workflow_mode: current_branch
+    allowed_workflow_modes:
+      - current_branch
     allowed_branch_patterns:
       - "^main$"
   - path: ~/dot.files
     workflow_mode: current_branch
+    allowed_workflow_modes:
+      - current_branch
     allowed_branch_patterns:
       - "^main$"
 ```
 
 If you want to bootstrap the config and then add this repository incrementally, a minimal progression is:
 
-1. Call `config_bootstrap` with defaults such as `feature_branch_pattern` or `workflow_mode`.
-2. Call `config_upsert_repo` with `repo_path`, and optionally `git_worktree_base_path`, `default_remote`, `allowed_branch_patterns`, or `workflow_mode`.
+1. Call `config_bootstrap` with defaults such as `feature_branch_pattern`, `workflow_mode`, or `allowed_workflow_modes`.
+2. Call `config_upsert_repo` with `repo_path`, and optionally `git_worktree_base_path`, `default_remote`, `allowed_branch_patterns`, `workflow_mode`, or `allowed_workflow_modes`.
 3. Use the Git tools against that repository; they will reload the YAML on each call.
 ```

--- a/SPEC.md
+++ b/SPEC.md
@@ -156,7 +156,8 @@ Optional configuration that may be useful:
 - default remote name
 - whether draft PR creation is enabled
 - suggested feature branch naming pattern
-- a workflow mode (`worktree`, `feature_branch`, or `current_branch`) enforced for branch-setup tools
+- a preferred workflow mode (`worktree`, `feature_branch`, or `current_branch`) exposed as setup guidance
+- an explicit allowed workflow mode list enforced for branch-setup tools
 
 The initial branch and PR behavior should prefer runtime inference with a narrow fallback order:
 
@@ -175,6 +176,9 @@ repositories:
       - "^feature/[a-z0-9._-]+$"
     allow_draft_prs: true
     workflow_mode: worktree
+    allowed_workflow_modes:
+      - feature_branch
+      - worktree
 ```
 
 ## Describe Support

--- a/src/auth/branchingPolicy.ts
+++ b/src/auth/branchingPolicy.ts
@@ -6,11 +6,9 @@ export function requireWorkflowMode(
   toolName: string,
   allowedModes: WorkflowMode[],
 ): void {
-  if (!repo.workflowMode) {
-    return;
-  }
+  const allowedWorkflowModes = repo.allowedWorkflowModes ?? (repo.workflowMode ? [repo.workflowMode] : undefined);
 
-  if (!allowedModes.includes(repo.workflowMode)) {
-    throw new BranchingPolicyViolationError(toolName, repo.worktreePath, repo.workflowMode);
+  if (!allowedWorkflowModes?.some((mode) => allowedModes.includes(mode))) {
+    throw new BranchingPolicyViolationError(toolName, repo.worktreePath, repo.workflowMode, repo.allowedWorkflowModes);
   }
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -323,7 +323,11 @@ function applyRepoOverrides(
   repoLocalPolicy: RepoPolicy,
   repoOverrides: RepoPolicyOverrides,
 ): RepoPolicy {
-  return {
+  const workflowMode = repoOverrides.workflowMode ?? repoLocalPolicy.workflowMode;
+  const allowedWorkflowModes =
+    repoOverrides.allowedWorkflowModes ??
+    (repoOverrides.workflowMode !== undefined ? [repoOverrides.workflowMode] : repoLocalPolicy.allowedWorkflowModes);
+  const mergedPolicy: RepoPolicy = {
     ...repoLocalPolicy,
     ...(repoOverrides.allowedBranchPatterns !== undefined
       ? { allowedBranchPatterns: repoOverrides.allowedBranchPatterns }
@@ -332,9 +336,16 @@ function applyRepoOverrides(
     ...(repoOverrides.gitWorktreeBasePath !== undefined ? { gitWorktreeBasePath: repoOverrides.gitWorktreeBasePath } : {}),
     ...(repoOverrides.defaultRemote !== undefined ? { defaultRemote: repoOverrides.defaultRemote } : {}),
     ...(repoOverrides.allowDraftPrs !== undefined ? { allowDraftPrs: repoOverrides.allowDraftPrs } : {}),
-    ...(repoOverrides.workflowMode !== undefined ? { workflowMode: repoOverrides.workflowMode } : {}),
-    ...(repoOverrides.allowedWorkflowModes !== undefined ? { allowedWorkflowModes: repoOverrides.allowedWorkflowModes } : {}),
+    ...(workflowMode !== undefined ? { workflowMode } : {}),
+    ...(allowedWorkflowModes !== undefined ? { allowedWorkflowModes } : {}),
     repoOverridesApplied: true,
+  };
+
+  const effectiveAllowedWorkflowModes = resolveAllowedWorkflowModes(mergedPolicy.allowedWorkflowModes, mergedPolicy.workflowMode);
+
+  return {
+    ...mergedPolicy,
+    ...(effectiveAllowedWorkflowModes !== undefined ? { allowedWorkflowModes: effectiveAllowedWorkflowModes } : {}),
   };
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -115,6 +115,7 @@ export async function loadRepoLocalPolicy(
     allowDraftPrs: parsed.allow_draft_prs ?? true,
     workflowMode: parsed.workflow_mode,
     allowedWorkflowModes: resolveAllowedWorkflowModes(parsed.allowed_workflow_modes, parsed.workflow_mode),
+    allowedWorkflowModesConfigured: parsed.allowed_workflow_modes !== undefined,
     policySource: "repo_local",
     repoLocalConfigPath: configPath,
     repoLocalConfigRelativePath: REPO_LOCAL_CONFIG_FILENAME,
@@ -222,6 +223,8 @@ async function normalizeConfig(config: EditableConfig): Promise<Config> {
       repo.allowed_workflow_modes ?? config.defaults?.allowed_workflow_modes,
       workflowMode,
     );
+    const allowedWorkflowModesConfigured =
+      repo.allowed_workflow_modes !== undefined || config.defaults?.allowed_workflow_modes !== undefined;
     const repoOverrides = buildRepoOverrides({
       allowedBranchPatterns:
         repo.allowed_branch_patterns === undefined ? undefined : compileBranchPatterns(repo.allowed_branch_patterns, repo.path),
@@ -231,6 +234,7 @@ async function normalizeConfig(config: EditableConfig): Promise<Config> {
       allowDraftPrs: repo.allow_draft_prs,
       workflowMode: repo.workflow_mode,
       allowedWorkflowModes: resolveRepoAllowedWorkflowModesOverride(repo),
+      allowedWorkflowModesConfigured: repo.allowed_workflow_modes !== undefined,
     });
 
     repositories.push({
@@ -244,6 +248,7 @@ async function normalizeConfig(config: EditableConfig): Promise<Config> {
       allowDraftPrs: repo.allow_draft_prs ?? config.defaults?.allow_draft_prs ?? true,
       workflowMode,
       allowedWorkflowModes,
+      allowedWorkflowModesConfigured,
       policySource: "global",
       repoOverrides,
       repoOverridesApplied: repoOverrides !== undefined,
@@ -314,6 +319,7 @@ function buildRepoOverrides(input: RepoPolicyOverrides): RepoPolicyOverrides | u
     ...(input.allowDraftPrs !== undefined ? { allowDraftPrs: input.allowDraftPrs } : {}),
     ...(input.workflowMode !== undefined ? { workflowMode: input.workflowMode } : {}),
     ...(input.allowedWorkflowModes !== undefined ? { allowedWorkflowModes: input.allowedWorkflowModes } : {}),
+    ...(input.allowedWorkflowModesConfigured ? { allowedWorkflowModesConfigured: input.allowedWorkflowModesConfigured } : {}),
   };
 
   return Object.keys(overrides).length > 0 ? overrides : undefined;
@@ -326,7 +332,9 @@ function applyRepoOverrides(
   const workflowMode = repoOverrides.workflowMode ?? repoLocalPolicy.workflowMode;
   const allowedWorkflowModes =
     repoOverrides.allowedWorkflowModes ??
-    (repoOverrides.workflowMode !== undefined ? [repoOverrides.workflowMode] : repoLocalPolicy.allowedWorkflowModes);
+    (repoOverrides.workflowMode !== undefined && !repoLocalPolicy.allowedWorkflowModesConfigured
+      ? [repoOverrides.workflowMode]
+      : repoLocalPolicy.allowedWorkflowModes);
   const mergedPolicy: RepoPolicy = {
     ...repoLocalPolicy,
     ...(repoOverrides.allowedBranchPatterns !== undefined
@@ -338,6 +346,8 @@ function applyRepoOverrides(
     ...(repoOverrides.allowDraftPrs !== undefined ? { allowDraftPrs: repoOverrides.allowDraftPrs } : {}),
     ...(workflowMode !== undefined ? { workflowMode } : {}),
     ...(allowedWorkflowModes !== undefined ? { allowedWorkflowModes } : {}),
+    allowedWorkflowModesConfigured:
+      repoOverrides.allowedWorkflowModesConfigured ?? repoLocalPolicy.allowedWorkflowModesConfigured,
     repoOverridesApplied: true,
   };
 
@@ -352,10 +362,6 @@ function applyRepoOverrides(
 function resolveRepoAllowedWorkflowModesOverride(repo: EditableRepoPolicy): WorkflowMode[] | undefined {
   if (repo.allowed_workflow_modes !== undefined) {
     return resolveAllowedWorkflowModes(repo.allowed_workflow_modes, repo.workflow_mode);
-  }
-
-  if (repo.workflow_mode !== undefined) {
-    return [repo.workflow_mode];
   }
 
   return undefined;

--- a/src/config.ts
+++ b/src/config.ts
@@ -192,6 +192,8 @@ async function normalizeConfig(config: EditableConfig): Promise<Config> {
   const repositories: RepoPolicy[] = [];
   const seenPaths = new Set<string>();
 
+  resolveAllowedWorkflowModes(config.defaults?.allowed_workflow_modes, config.defaults?.workflow_mode);
+
   for (const repo of config.repositories) {
     const expandedPath = expandHomeDir(repo.path);
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -11,6 +11,7 @@ import type { Config, RepoPolicy, RepoPolicyOverrides, WorkflowMode } from "./ty
 export const REPO_LOCAL_CONFIG_FILENAME = ".git-unleash.yaml";
 
 const workflowModeSchema = z.enum(["worktree", "feature_branch", "current_branch"]);
+const allowedWorkflowModesSchema = z.array(workflowModeSchema).nonempty();
 
 const policyDefaultsSchema = z.object({
   allowed_branch_patterns: z.array(z.string().min(1)).nonempty().optional(),
@@ -19,6 +20,7 @@ const policyDefaultsSchema = z.object({
   default_remote: z.string().min(1).optional(),
   allow_draft_prs: z.boolean().optional(),
   workflow_mode: workflowModeSchema.optional(),
+  allowed_workflow_modes: allowedWorkflowModesSchema.optional(),
 });
 
 const repoPolicySchema = policyDefaultsSchema.extend({
@@ -32,6 +34,7 @@ const repoLocalPolicySchema = z.object({
   default_remote: z.string().min(1).optional(),
   allow_draft_prs: z.boolean().optional(),
   workflow_mode: workflowModeSchema.optional(),
+  allowed_workflow_modes: allowedWorkflowModesSchema.optional(),
 });
 
 const configSchema = z.object({
@@ -111,6 +114,7 @@ export async function loadRepoLocalPolicy(
     gitWorktreeBasePath: await resolveGitWorktreeBasePath(parsed.git_worktree_base_path, { repoRoot: canonicalRepoRoot }),
     allowDraftPrs: parsed.allow_draft_prs ?? true,
     workflowMode: parsed.workflow_mode,
+    allowedWorkflowModes: resolveAllowedWorkflowModes(parsed.allowed_workflow_modes, parsed.workflow_mode),
     policySource: "repo_local",
     repoLocalConfigPath: configPath,
     repoLocalConfigRelativePath: REPO_LOCAL_CONFIG_FILENAME,
@@ -214,6 +218,10 @@ async function normalizeConfig(config: EditableConfig): Promise<Config> {
     const patternSources = repo.allowed_branch_patterns ?? config.defaults?.allowed_branch_patterns ?? [];
     const allowedBranchPatterns = compileBranchPatterns(patternSources, repo.path);
     const workflowMode = repo.workflow_mode ?? config.defaults?.workflow_mode;
+    const allowedWorkflowModes = resolveAllowedWorkflowModes(
+      repo.allowed_workflow_modes ?? config.defaults?.allowed_workflow_modes,
+      workflowMode,
+    );
     const repoOverrides = buildRepoOverrides({
       allowedBranchPatterns:
         repo.allowed_branch_patterns === undefined ? undefined : compileBranchPatterns(repo.allowed_branch_patterns, repo.path),
@@ -222,6 +230,7 @@ async function normalizeConfig(config: EditableConfig): Promise<Config> {
       defaultRemote: repo.default_remote,
       allowDraftPrs: repo.allow_draft_prs,
       workflowMode: repo.workflow_mode,
+      allowedWorkflowModes: resolveRepoAllowedWorkflowModesOverride(repo),
     });
 
     repositories.push({
@@ -234,6 +243,7 @@ async function normalizeConfig(config: EditableConfig): Promise<Config> {
       defaultRemote: repo.default_remote ?? config.defaults?.default_remote,
       allowDraftPrs: repo.allow_draft_prs ?? config.defaults?.allow_draft_prs ?? true,
       workflowMode,
+      allowedWorkflowModes,
       policySource: "global",
       repoOverrides,
       repoOverridesApplied: repoOverrides !== undefined,
@@ -291,6 +301,7 @@ function toOptionalPolicyDefaults(input: Partial<EditablePolicyDefaults>): Edita
     ...(input.default_remote ? { default_remote: input.default_remote } : {}),
     ...(input.allow_draft_prs !== undefined ? { allow_draft_prs: input.allow_draft_prs } : {}),
     ...(input.workflow_mode ? { workflow_mode: input.workflow_mode } : {}),
+    ...(input.allowed_workflow_modes ? { allowed_workflow_modes: input.allowed_workflow_modes } : {}),
   };
 }
 
@@ -302,6 +313,7 @@ function buildRepoOverrides(input: RepoPolicyOverrides): RepoPolicyOverrides | u
     ...(input.defaultRemote !== undefined ? { defaultRemote: input.defaultRemote } : {}),
     ...(input.allowDraftPrs !== undefined ? { allowDraftPrs: input.allowDraftPrs } : {}),
     ...(input.workflowMode !== undefined ? { workflowMode: input.workflowMode } : {}),
+    ...(input.allowedWorkflowModes !== undefined ? { allowedWorkflowModes: input.allowedWorkflowModes } : {}),
   };
 
   return Object.keys(overrides).length > 0 ? overrides : undefined;
@@ -321,8 +333,42 @@ function applyRepoOverrides(
     ...(repoOverrides.defaultRemote !== undefined ? { defaultRemote: repoOverrides.defaultRemote } : {}),
     ...(repoOverrides.allowDraftPrs !== undefined ? { allowDraftPrs: repoOverrides.allowDraftPrs } : {}),
     ...(repoOverrides.workflowMode !== undefined ? { workflowMode: repoOverrides.workflowMode } : {}),
+    ...(repoOverrides.allowedWorkflowModes !== undefined ? { allowedWorkflowModes: repoOverrides.allowedWorkflowModes } : {}),
     repoOverridesApplied: true,
   };
+}
+
+function resolveRepoAllowedWorkflowModesOverride(repo: EditableRepoPolicy): WorkflowMode[] | undefined {
+  if (repo.allowed_workflow_modes !== undefined) {
+    return resolveAllowedWorkflowModes(repo.allowed_workflow_modes, repo.workflow_mode);
+  }
+
+  if (repo.workflow_mode !== undefined) {
+    return [repo.workflow_mode];
+  }
+
+  return undefined;
+}
+
+function resolveAllowedWorkflowModes(
+  allowedWorkflowModes: WorkflowMode[] | undefined,
+  workflowMode: WorkflowMode | undefined,
+): WorkflowMode[] | undefined {
+  const modes = allowedWorkflowModes ?? (workflowMode ? [workflowMode] : undefined);
+  if (!modes) {
+    return undefined;
+  }
+
+  const uniqueModes = [...new Set(modes)];
+  if (uniqueModes.includes("current_branch") && uniqueModes.length > 1) {
+    throw new ConfigError("allowed_workflow_modes cannot combine current_branch with feature_branch or worktree");
+  }
+
+  if (workflowMode && !uniqueModes.includes(workflowMode)) {
+    throw new ConfigError(`workflow_mode '${workflowMode}' must be included in allowed_workflow_modes`);
+  }
+
+  return uniqueModes;
 }
 
 function resolveFeatureBranchPattern(pattern: string | undefined): string | undefined {

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -38,9 +38,14 @@ export class BranchNameNotAllowedError extends Error {
 }
 
 export class BranchingPolicyViolationError extends Error {
-  constructor(toolName: string, repoPath: string, actualMode: string) {
+  constructor(toolName: string, repoPath: string, workflowMode?: string, allowedWorkflowModes?: string[]) {
+    const policySummary = allowedWorkflowModes?.length
+      ? `allowed_workflow_modes '${allowedWorkflowModes.join(", ")}'`
+      : workflowMode
+        ? `workflow_mode '${workflowMode}'`
+        : "no configured workflow policy";
     super(
-      `tool '${toolName}' is not allowed for repository '${repoPath}' under workflow_mode '${actualMode}'; call 'git_repo_policy' and use the configured setup flow`,
+      `tool '${toolName}' is not allowed for repository '${repoPath}' under ${policySummary}; call 'git_repo_policy' and use an allowed setup flow`,
     );
     this.name = "BranchingPolicyViolationError";
   }

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -45,7 +45,7 @@ export class BranchingPolicyViolationError extends Error {
         ? `workflow_mode '${workflowMode}'`
         : "no configured workflow policy";
     super(
-      `tool '${toolName}' is not allowed for repository '${repoPath}' under ${policySummary}; call 'git_repo_policy' and use an allowed setup flow`,
+      `tool '${toolName}' is not allowed for repository '${repoPath}' under ${policySummary}; call 'git_repo_policy' to inspect the preferred workflow_mode and allowed setup flows`,
     );
     this.name = "BranchingPolicyViolationError";
   }

--- a/src/server.ts
+++ b/src/server.ts
@@ -263,7 +263,7 @@ export function createServer(configPath: string): McpServer {
 
   server.tool(
     "git_branch_switch",
-    "Switch to an existing local branch in an authorized repository. This tool mutates repository state, requires the worktree to be clean, requires the target branch name to match configured allowed patterns, is only allowed when workflow_mode is unset or feature_branch, only accepts an explicit local branch name, and does not create branches or allow detached checkouts.",
+    "Switch to an existing local branch in an authorized repository. This tool mutates repository state, requires the worktree to be clean, requires the target branch name to match configured allowed patterns, requires feature_branch in the effective allowed workflow modes, only accepts an explicit local branch name, and does not create branches or allow detached checkouts.",
     {
       repo_path: z.string().min(1),
       branch: z.string(),

--- a/src/server.ts
+++ b/src/server.ts
@@ -21,6 +21,7 @@ import { gitSyncBase } from "./tools/gitSyncBase.js";
 import { gitWorktreeAdd } from "./tools/gitWorktreeAdd.js";
 
 const workflowModeSchema = z.enum(["worktree", "feature_branch", "current_branch"]);
+const allowedWorkflowModesSchema = z.array(workflowModeSchema).min(1);
 
 const configPolicyFields = {
   allowed_branch_patterns: z.array(z.string().min(1)).min(1).optional(),
@@ -29,6 +30,7 @@ const configPolicyFields = {
   default_remote: z.string().min(1).optional(),
   allow_draft_prs: z.boolean().optional(),
   workflow_mode: workflowModeSchema.optional(),
+  allowed_workflow_modes: allowedWorkflowModesSchema.optional(),
 };
 
 const CLOSED_WORLD_READ_ONLY_TOOL: ToolAnnotations = {

--- a/src/server.ts
+++ b/src/server.ts
@@ -239,7 +239,7 @@ export function createServer(configPath: string): McpServer {
 
   server.tool(
     "git_branch_create_and_switch",
-    "Create a new local branch from an explicit or detected upstream base branch for an authorized repository, then switch to it. This tool requires a clean worktree, resolves the remote at runtime, fetches the chosen base branch first, and does not accept arbitrary source refs or detached targets.",
+    "Create a new local branch from an explicit or detected upstream base branch for an authorized repository, then switch to it. This tool requires a clean worktree, requires feature_branch in the effective allowed workflow modes, resolves the remote at runtime, fetches the chosen base branch first, and does not accept arbitrary source refs or detached targets.",
     {
       repo_path: z.string().min(1),
       new_branch: z.string(),
@@ -353,7 +353,7 @@ export function createServer(configPath: string): McpServer {
 
   server.tool(
     "git_worktree_add",
-    "Create a linked worktree at an explicit absolute path for a new local branch in an authorized repository. This tool mutates repository state, validates the requested branch name against configured full-match patterns, fetches the chosen base branch first, and enforces the configured worktree base path when one exists.",
+    "Create a linked worktree at an explicit absolute path for a new local branch in an authorized repository. This tool mutates repository state, requires worktree in the effective allowed workflow modes, validates the requested branch name against configured full-match patterns, fetches the chosen base branch first, and enforces the configured worktree base path when one exists.",
     {
       repo_path: z.string().min(1),
       path: z.string().min(1),

--- a/src/tools/gitRepoPolicy.ts
+++ b/src/tools/gitRepoPolicy.ts
@@ -9,6 +9,7 @@ export type GitRepoPolicyResult = {
   defaultRemote?: string;
   allowDraftPrs: boolean;
   workflowMode?: string;
+  allowedWorkflowModes?: string[];
   policySource: string;
   repoLocalConfigPath?: string;
   repoOverridesApplied: boolean;
@@ -24,6 +25,7 @@ export function getGitRepoPolicy(repo: RepoPolicy): GitRepoPolicyResult {
     defaultRemote: repo.defaultRemote,
     allowDraftPrs: repo.allowDraftPrs,
     workflowMode: repo.workflowMode,
+    allowedWorkflowModes: repo.allowedWorkflowModes,
     policySource: repo.policySource,
     repoLocalConfigPath: repo.repoLocalConfigPath,
     repoOverridesApplied: repo.repoOverridesApplied ?? false,

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -8,6 +8,7 @@ export type RepoPolicyOverrides = {
   defaultRemote?: string;
   allowDraftPrs?: boolean;
   workflowMode?: WorkflowMode;
+  allowedWorkflowModes?: WorkflowMode[];
 };
 
 export type RepoPolicy = {
@@ -20,6 +21,7 @@ export type RepoPolicy = {
   defaultRemote?: string;
   allowDraftPrs: boolean;
   workflowMode?: WorkflowMode;
+  allowedWorkflowModes?: WorkflowMode[];
   policySource: RepoPolicySource;
   repoLocalConfigPath?: string;
   repoLocalConfigRelativePath?: string;

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -9,6 +9,7 @@ export type RepoPolicyOverrides = {
   allowDraftPrs?: boolean;
   workflowMode?: WorkflowMode;
   allowedWorkflowModes?: WorkflowMode[];
+  allowedWorkflowModesConfigured?: boolean;
 };
 
 export type RepoPolicy = {
@@ -22,6 +23,7 @@ export type RepoPolicy = {
   allowDraftPrs: boolean;
   workflowMode?: WorkflowMode;
   allowedWorkflowModes?: WorkflowMode[];
+  allowedWorkflowModesConfigured?: boolean;
   policySource: RepoPolicySource;
   repoLocalConfigPath?: string;
   repoLocalConfigRelativePath?: string;

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -421,6 +421,18 @@ describe("bootstrapConfig", () => {
       new ConfigError(`config file '${configPath}' already exists`),
     );
   });
+
+  it("rejects defaults whose workflow preference is not allowed", async () => {
+    const configPath = path.join(os.tmpdir(), `git-mcp-config-${Date.now()}-bootstrap-invalid-workflow-defaults.yaml`);
+    tempPaths.push(configPath);
+
+    await expect(
+      bootstrapConfig(configPath, {
+        workflow_mode: "worktree",
+        allowed_workflow_modes: ["feature_branch"],
+      }),
+    ).rejects.toThrow("workflow_mode 'worktree' must be included in allowed_workflow_modes");
+  });
 });
 
 describe("upsertRepoConfig", () => {

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -433,6 +433,7 @@ describe("upsertRepoConfig", () => {
       repo_path: repoDir,
       allowed_branch_patterns: ["^owner\\/.*$"],
       workflow_mode: "worktree",
+      allowed_workflow_modes: ["feature_branch", "worktree"],
     });
 
     expect(result).toEqual({
@@ -441,6 +442,7 @@ describe("upsertRepoConfig", () => {
         path: repoDir,
         allowed_branch_patterns: ["^owner\\/.*$"],
         workflow_mode: "worktree",
+        allowed_workflow_modes: ["feature_branch", "worktree"],
       },
     });
 
@@ -448,6 +450,56 @@ describe("upsertRepoConfig", () => {
     expect(config.repositories).toHaveLength(1);
     expect(config.repositories[0]?.path).toBe(repoDir);
     expect(config.repositories[0]?.workflowMode).toBe("worktree");
+    expect(config.repositories[0]?.allowedWorkflowModes).toEqual(["feature_branch", "worktree"]);
+  });
+
+  it("rejects allowed workflow modes that combine current_branch with setup flows", async () => {
+    const repoDir = await fs.mkdtemp(path.join(os.tmpdir(), "git-mcp-invalid-workflow-modes-repo-"));
+    const configPath = path.join(os.tmpdir(), `git-mcp-config-${Date.now()}-invalid-workflow-modes.yaml`);
+    tempPaths.push(repoDir, configPath);
+
+    await fs.writeFile(
+      configPath,
+      [
+        "repositories:",
+        `  - path: ${repoDir}`,
+        "    allowed_branch_patterns:",
+        '      - "^owner\\/.*$"',
+        "    workflow_mode: current_branch",
+        "    allowed_workflow_modes:",
+        "      - current_branch",
+        "      - worktree",
+      ].join("\n"),
+      "utf8",
+    );
+
+    await expect(loadConfig(configPath)).rejects.toThrow(
+      "allowed_workflow_modes cannot combine current_branch with feature_branch or worktree",
+    );
+  });
+
+  it("rejects workflow preferences that are not included in allowed workflow modes", async () => {
+    const repoDir = await fs.mkdtemp(path.join(os.tmpdir(), "git-mcp-mismatched-workflow-modes-repo-"));
+    const configPath = path.join(os.tmpdir(), `git-mcp-config-${Date.now()}-mismatched-workflow-modes.yaml`);
+    tempPaths.push(repoDir, configPath);
+
+    await fs.writeFile(
+      configPath,
+      [
+        "repositories:",
+        `  - path: ${repoDir}`,
+        "    allowed_branch_patterns:",
+        '      - "^owner\\/.*$"',
+        "    workflow_mode: worktree",
+        "    allowed_workflow_modes:",
+        "      - feature_branch",
+      ].join("\n"),
+      "utf8",
+    );
+
+    await expect(loadConfig(configPath)).rejects.toThrow(
+      "workflow_mode 'worktree' must be included in allowed_workflow_modes",
+    );
   });
 
   it("updates an existing repo entry matched by canonical path", async () => {

--- a/tests/gitBranchCreateAndSwitch.test.ts
+++ b/tests/gitBranchCreateAndSwitch.test.ts
@@ -133,7 +133,55 @@ describe("gitBranchCreateAndSwitch", () => {
     ).rejects.toBeInstanceOf(BranchNameNotAllowedError);
   });
 
-  it("rejects branch creation when workflow_mode excludes feature_branch", async () => {
+  it("allows branch creation when explicitly included in allowed workflow modes", async () => {
+    const { repoDir, repo } = await createTempGitRepo();
+    const remoteDir = await createTempBareGitRepo();
+    tempPaths.push(repoDir, remoteDir);
+
+    await runCommand({ cwd: repoDir, command: "git", argv: ["remote", "add", "origin", remoteDir] });
+    await fs.writeFile(path.join(repoDir, "README.md"), "hello\n", "utf8");
+    await gitAdd(repo, ["README.md"]);
+    await gitCommit(repo, "add readme");
+    await gitPush(repo, "main");
+    await runCommand({
+      cwd: remoteDir,
+      command: "git",
+      argv: ["symbolic-ref", "HEAD", "refs/heads/main"],
+    });
+
+    const result = await gitBranchCreateAndSwitch(
+      {
+        ...repo,
+        workflowMode: "worktree",
+        allowedWorkflowModes: ["feature_branch", "worktree"],
+      },
+      { newBranch: "feature/from-explicit-branch" },
+    );
+
+    expect(result).toEqual({
+      branch: "feature/from-explicit-branch",
+      remote: "origin",
+      base: "main",
+    });
+  });
+
+  it("rejects branch creation when allowed workflow modes are omitted", async () => {
+    const { repoDir, repo } = await createTempGitRepo();
+    tempPaths.push(repoDir);
+
+    await expect(
+      gitBranchCreateAndSwitch(
+        {
+          ...repo,
+          workflowMode: undefined,
+          allowedWorkflowModes: undefined,
+        },
+        { newBranch: "feature/from-unconfigured-policy" },
+      ),
+    ).rejects.toBeInstanceOf(BranchingPolicyViolationError);
+  });
+
+  it("rejects branch creation when allowed workflow modes exclude feature_branch", async () => {
     const { repoDir, repo } = await createTempGitRepo();
     tempPaths.push(repoDir);
 
@@ -142,6 +190,7 @@ describe("gitBranchCreateAndSwitch", () => {
         {
           ...repo,
           workflowMode: "worktree",
+          allowedWorkflowModes: ["worktree"],
         },
         { newBranch: "feature/from-branch-tool" },
       ),
@@ -157,6 +206,7 @@ describe("gitBranchCreateAndSwitch", () => {
         {
           ...repo,
           workflowMode: "current_branch",
+          allowedWorkflowModes: ["current_branch"],
         },
         { newBranch: "feature/from-current-branch" },
       ),

--- a/tests/gitBranchSwitch.test.ts
+++ b/tests/gitBranchSwitch.test.ts
@@ -89,7 +89,23 @@ describe("gitBranchSwitch", () => {
     await expect(gitBranchSwitch(repo, "   ")).rejects.toBeInstanceOf(EmptyBranchNameError);
   });
 
-  it("rejects switching when workflow_mode excludes feature_branch", async () => {
+  it("rejects switching when allowed workflow modes are omitted", async () => {
+    const { repoDir, repo } = await createTempGitRepo();
+    tempPaths.push(repoDir);
+
+    await expect(
+      gitBranchSwitch(
+        {
+          ...repo,
+          workflowMode: undefined,
+          allowedWorkflowModes: undefined,
+        },
+        "main",
+      ),
+    ).rejects.toBeInstanceOf(BranchingPolicyViolationError);
+  });
+
+  it("rejects switching when allowed workflow modes exclude feature_branch", async () => {
     const { repoDir, repo } = await createTempGitRepo();
     tempPaths.push(repoDir);
 
@@ -98,6 +114,7 @@ describe("gitBranchSwitch", () => {
         {
           ...repo,
           workflowMode: "worktree",
+          allowedWorkflowModes: ["worktree"],
         },
         "main",
       ),
@@ -113,6 +130,7 @@ describe("gitBranchSwitch", () => {
         {
           ...repo,
           workflowMode: "current_branch",
+          allowedWorkflowModes: ["current_branch"],
         },
         "main",
       ),

--- a/tests/gitRepoPolicy.test.ts
+++ b/tests/gitRepoPolicy.test.ts
@@ -15,6 +15,7 @@ describe("getGitRepoPolicy", () => {
       defaultRemote: "origin",
       allowDraftPrs: true,
       workflowMode: "feature_branch",
+      allowedWorkflowModes: ["feature_branch", "worktree"],
       policySource: "global",
       repoOverridesApplied: true,
     };
@@ -28,6 +29,7 @@ describe("getGitRepoPolicy", () => {
       defaultRemote: "origin",
       allowDraftPrs: true,
       workflowMode: "feature_branch",
+      allowedWorkflowModes: ["feature_branch", "worktree"],
       policySource: "global",
       repoLocalConfigPath: undefined,
       repoOverridesApplied: true,

--- a/tests/gitWorktreeAdd.test.ts
+++ b/tests/gitWorktreeAdd.test.ts
@@ -124,7 +124,59 @@ describe("gitWorktreeAdd", () => {
     ).rejects.toBeInstanceOf(BranchNameNotAllowedError);
   });
 
-  it("rejects worktree creation when workflow_mode excludes worktree", async () => {
+  it("allows worktree creation when explicitly included in allowed workflow modes", async () => {
+    const { repoDir, repo } = await createTempGitRepo();
+    const remoteDir = await createTempBareGitRepo();
+    const worktreeParentDir = await fs.mkdtemp(path.join(os.tmpdir(), "git-mcp-worktree-add-allowed-parent-"));
+    const worktreeDir = path.join(worktreeParentDir, "linked");
+    tempPaths.push(repoDir, remoteDir, worktreeParentDir);
+
+    await runCommand({ cwd: repoDir, command: "git", argv: ["remote", "add", "origin", remoteDir] });
+    await fs.writeFile(path.join(repoDir, "README.md"), "hello\n", "utf8");
+    await gitAdd(repo, ["README.md"]);
+    await gitCommit(repo, "add readme");
+    await gitPush(repo, "main");
+    await runCommand({
+      cwd: remoteDir,
+      command: "git",
+      argv: ["symbolic-ref", "HEAD", "refs/heads/main"],
+    });
+
+    const result = await gitWorktreeAdd(
+      {
+        ...repo,
+        workflowMode: "feature_branch",
+        allowedWorkflowModes: ["feature_branch", "worktree"],
+      },
+      {
+        path: worktreeDir,
+        newBranch: "feature/from-explicit-worktree",
+      },
+    );
+
+    await expect(getCurrentBranch(result.path)).resolves.toBe("feature/from-explicit-worktree");
+  });
+
+  it("rejects worktree creation when allowed workflow modes are omitted", async () => {
+    const { repoDir, repo } = await createTempGitRepo();
+    tempPaths.push(repoDir);
+
+    await expect(
+      gitWorktreeAdd(
+        {
+          ...repo,
+          workflowMode: undefined,
+          allowedWorkflowModes: undefined,
+        },
+        {
+          path: "/tmp/git-mcp-unconfigured-worktree",
+          newBranch: "feature/from-unconfigured-policy",
+        },
+      ),
+    ).rejects.toBeInstanceOf(BranchingPolicyViolationError);
+  });
+
+  it("rejects worktree creation when allowed workflow modes exclude worktree", async () => {
     const { repoDir, repo } = await createTempGitRepo();
     tempPaths.push(repoDir);
 
@@ -133,6 +185,7 @@ describe("gitWorktreeAdd", () => {
         {
           ...repo,
           workflowMode: "feature_branch",
+          allowedWorkflowModes: ["feature_branch"],
         },
         {
           path: "/tmp/git-mcp-policy-mismatch-worktree",
@@ -151,6 +204,7 @@ describe("gitWorktreeAdd", () => {
         {
           ...repo,
           workflowMode: "current_branch",
+          allowedWorkflowModes: ["current_branch"],
         },
         {
           path: "/tmp/git-mcp-current-branch-worktree",

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -19,6 +19,7 @@ export async function createTempGitRepo(): Promise<{ repoDir: string; repo: Repo
       worktreePath: await fs.realpath(repoDir),
       allowedBranchPatterns: [/^.*$/],
       allowDraftPrs: true,
+      allowedWorkflowModes: ["feature_branch", "worktree"],
       policySource: "global",
     },
   };

--- a/tests/repoAuth.test.ts
+++ b/tests/repoAuth.test.ts
@@ -145,6 +145,42 @@ describe("resolveAllowedRepo", () => {
     expect(resolvedRepo.repoOverridesApplied).toBe(true);
   });
 
+  it("rejects global overrides that make repo-local workflow policy incoherent", async () => {
+    const { repoDir } = await createTempGitRepo();
+    tempPaths.push(repoDir);
+
+    await fs.writeFile(
+      path.join(repoDir, ".git-unleash.yaml"),
+      [
+        "allowed_branch_patterns:",
+        '  - "^owner/.+$"',
+        "workflow_mode: current_branch",
+      ].join("\n"),
+      "utf8",
+    );
+
+    const configPath = path.join(os.tmpdir(), `git-mcp-config-${Date.now()}-repo-local-workflow-override.yaml`);
+    tempPaths.push(configPath);
+
+    await fs.writeFile(
+      configPath,
+      [
+        "repositories:",
+        `  - path: ${repoDir}`,
+        "    allowed_workflow_modes:",
+        "      - feature_branch",
+        "      - worktree",
+      ].join("\n"),
+      "utf8",
+    );
+
+    const config = await loadConfig(configPath);
+
+    await expect(resolveAllowedRepo(config, repoDir)).rejects.toThrow(
+      "workflow_mode 'current_branch' must be included in allowed_workflow_modes",
+    );
+  });
+
   it("does not apply top-level defaults over repo-local policy", async () => {
     const { repoDir } = await createTempGitRepo();
     tempPaths.push(repoDir);

--- a/tests/repoAuth.test.ts
+++ b/tests/repoAuth.test.ts
@@ -181,6 +181,44 @@ describe("resolveAllowedRepo", () => {
     );
   });
 
+  it("preserves repo-local allowed workflow modes when global overrides only set workflow preference", async () => {
+    const { repoDir } = await createTempGitRepo();
+    tempPaths.push(repoDir);
+
+    await fs.writeFile(
+      path.join(repoDir, ".git-unleash.yaml"),
+      [
+        "allowed_branch_patterns:",
+        '  - "^owner/.+$"',
+        "workflow_mode: feature_branch",
+        "allowed_workflow_modes:",
+        "  - feature_branch",
+        "  - worktree",
+      ].join("\n"),
+      "utf8",
+    );
+
+    const configPath = path.join(os.tmpdir(), `git-mcp-config-${Date.now()}-repo-local-workflow-preference.yaml`);
+    tempPaths.push(configPath);
+
+    await fs.writeFile(
+      configPath,
+      [
+        "repositories:",
+        `  - path: ${repoDir}`,
+        "    workflow_mode: worktree",
+      ].join("\n"),
+      "utf8",
+    );
+
+    const config = await loadConfig(configPath);
+    const resolvedRepo = await resolveAllowedRepo(config, repoDir);
+
+    expect(resolvedRepo.workflowMode).toBe("worktree");
+    expect(resolvedRepo.allowedWorkflowModes).toEqual(["feature_branch", "worktree"]);
+    expect(resolvedRepo.repoOverridesApplied).toBe(true);
+  });
+
   it("does not apply top-level defaults over repo-local policy", async () => {
     const { repoDir } = await createTempGitRepo();
     tempPaths.push(repoDir);

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -117,6 +117,19 @@ describe("createServer", () => {
       },
     });
   });
+
+  it("describes setup tool workflow mode requirements", () => {
+    const server = createServer("/tmp/config.yaml") as unknown as {
+      _registeredTools: Record<string, { description?: string }>;
+    };
+
+    expect(server._registeredTools.git_branch_create_and_switch?.description).toContain(
+      "requires feature_branch in the effective allowed workflow modes",
+    );
+    expect(server._registeredTools.git_worktree_add?.description).toContain(
+      "requires worktree in the effective allowed workflow modes",
+    );
+  });
 });
 
 describe("loadRuntimeConfig", () => {


### PR DESCRIPTION
## Why

`workflow_mode` was carrying two meanings at once: it told agents which setup flow to prefer, but it also acted as an exclusive authorization gate. That made it impossible to express the common policy of preferring feature branches while still allowing an agent-driven linked worktree for tasks where isolation is useful.

This PR adds `allowed_workflow_modes` as the explicit authorization boundary and keeps `workflow_mode` as preference metadata. Existing `workflow_mode`-only configs remain compatible by deriving the single allowed mode from the configured preference, while configs with neither field now fail closed for branch/worktree setup tools.

## Impact

Expected upside: repositories can authorize both `feature_branch` and `worktree` setup flows while still advertising a preferred default to agents through `git_repo_policy`.

Potential risk: repositories that relied on omitting `workflow_mode` as an implicit permissive setup policy will now need to configure `allowed_workflow_modes` or `workflow_mode` before using setup tools. That is intentional fail-closed behavior, and the error points callers back to `git_repo_policy`.

## Verification

- `npm test -- tests/gitWorktreeAdd.test.ts tests/gitBranchCreateAndSwitch.test.ts tests/gitBranchSwitch.test.ts tests/config.test.ts tests/gitRepoPolicy.test.ts`
- `npm run typecheck`
- `npm test -- --maxWorkers=1 --testTimeout=20000`