### PR TITLE
git-unleash: use git switch for branch switching

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,10 @@ The server is intentionally not a generic `git` or `gh` proxy. Inputs are struct
 
 - Node.js
 - npm
-- `git`
+- `git` 2.23 or newer
 - `gh`
+
+`git_branch_switch` uses `git switch` rather than `git checkout`, so Git 2.23+ is the supported baseline for branch switching.
 
 ## Install
 

--- a/src/exec/git.ts
+++ b/src/exec/git.ts
@@ -39,7 +39,7 @@ export function gitWorktreeAddArgs(worktreePath: string, newBranch: string, star
 }
 
 export function gitSwitchBranchArgs(branch: string): string[] {
-  return ["checkout", branch];
+  return ["switch", "--", branch];
 }
 
 export function gitRemoteGetUrlArgs(remote: string): string[] {

--- a/tests/gitArgs.test.ts
+++ b/tests/gitArgs.test.ts
@@ -51,7 +51,7 @@ describe("git argument builders", () => {
   });
 
   it("builds constrained git branch switch arguments", () => {
-    expect(gitSwitchBranchArgs("feature/test-pr")).toEqual(["checkout", "feature/test-pr"]);
+    expect(gitSwitchBranchArgs("feature/test-pr")).toEqual(["switch", "--", "feature/test-pr"]);
   });
 
   it("builds constrained git worktree add arguments", () => {

--- a/tests/gitBranchSwitch.test.ts
+++ b/tests/gitBranchSwitch.test.ts
@@ -169,6 +169,6 @@ describe("gitBranchSwitch", () => {
   });
 
   it("uses a fixed branch switch argument shape", () => {
-    expect(gitSwitchBranchArgs("feature/switch-me")).toEqual(["checkout", "feature/switch-me"]);
+    expect(gitSwitchBranchArgs("feature/switch-me")).toEqual(["switch", "--", "feature/switch-me"]);
   });
 });


### PR DESCRIPTION
## Why
`git_branch_switch` still built branch changes around `git checkout`, even though this tool only supports branch switching and already validates clean worktrees plus local branch existence. Switching that command builder to `git switch` makes the invoked Git operation match the tool's constrained intent more explicitly.

## Impact
Good:
- branch switching now uses the branch-specific Git command
- existing safety checks around branch existence and clean worktrees stay unchanged
- tests now pin the `git switch -- <branch>` argument shape

Potentially bad:
- branch switching now assumes Git 2.23+

## Validation
- `npm test -- tests/gitArgs.test.ts tests/gitBranchSwitch.test.ts`
- `npm test`

Closes #57