### PR TITLE
Pin auto-approve GitHub Action to an immutable SHA

### DIFF
--- a/.github/workflows/auto-approve-owner-prs.yml
+++ b/.github/workflows/auto-approve-owner-prs.yml
@@ -19,6 +19,6 @@ jobs:
 
     steps:
       - name: Approve PR
-        uses: hmarr/auto-approve-action@v4
+        uses: hmarr/auto-approve-action@f0939ea97e9205ef24d872e76833fa908a770363 # v4.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Why
`.github/workflows/auto-approve-owner-prs.yml` referenced `hmarr/auto-approve-action@v4`, which is a mutable major-version tag. Pinning the action to the upstream `v4.0.0` commit SHA hardens the workflow against tag movement or upstream compromise while preserving the intended release.

## Impact
This keeps the owner PR auto-approval workflow behavior unchanged aside from using an immutable action revision.

Potential downside: future upstream fixes to `hmarr/auto-approve-action` will require an explicit SHA bump instead of silently following `v4`.

Closes #47