### PR TITLE
Guard mutating tools against branch drift

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ Notes:
 - each repository must end up with at least one effective allowed branch pattern, either from the repo entry or inherited `defaults`
 - `git_repo_policy` returns the configured branch patterns and related repository defaults for an authorized repository, including `feature_branch_pattern`, `git_worktree_base_path`, the preferred `workflow_mode`, `allowed_workflow_modes`, the policy source, whether repo overrides were applied, and the repo-local config path when applicable
 - `git_add`, `git_stage`, `git_commit`, `git_sync_base`, `git_pull_current_branch`, `git_push`, and `gh_pr_create_draft` require the current branch to match one of the configured patterns
+- repository-mutating Git and GitHub tools are serialized per worktree inside the MCP process, and allowed-branch mutations re-check the current branch before returning success
+- that process-local lock does not stop a different process from changing the worktree concurrently, but branch drift is reported as an error instead of being reported as a clean success
 - `git_fetch` only requires the repository to be authorized, fetches from the resolved remote, updates local fetch metadata and remote-tracking state only, and uses an explicit branch when provided or the detected base branch otherwise
 - `git_sync_base` requires a clean worktree, fetches the detected remote base branch, merges only that remote-tracking ref into the current allowed branch, and aborts the merge before returning an error if a conflict occurs
 - `git_pull_current_branch` requires a clean worktree, fetches the current branch from the resolved remote, merges only that remote-tracking ref into the current allowed branch, and aborts the merge before returning an error if a conflict occurs

--- a/src/auth/repoMutation.ts
+++ b/src/auth/repoMutation.ts
@@ -1,0 +1,46 @@
+import { requireAllowedBranch } from "./branchAuth.js";
+import { BranchChangedDuringMutationError } from "../errors.js";
+import { getCurrentBranch } from "../exec/git.js";
+import type { RepoPolicy } from "../types/config.js";
+
+const repoMutationQueues = new Map<string, Promise<void>>();
+
+export async function withRepoMutationLock<T>(repo: RepoPolicy, operation: () => Promise<T>): Promise<T> {
+  const repoKey = repo.worktreePath;
+  const previous = repoMutationQueues.get(repoKey) ?? Promise.resolve();
+  const ready = previous.catch(() => undefined);
+  let releaseCurrent!: () => void;
+  const current = new Promise<void>((resolve) => {
+    releaseCurrent = resolve;
+  });
+  const queued = ready.then(() => current);
+  repoMutationQueues.set(repoKey, queued);
+
+  await ready;
+
+  try {
+    return await operation();
+  } finally {
+    releaseCurrent();
+    if (repoMutationQueues.get(repoKey) === queued) {
+      repoMutationQueues.delete(repoKey);
+    }
+  }
+}
+
+export async function withAllowedBranchMutation<T>(
+  repo: RepoPolicy,
+  operation: (branch: string) => Promise<T>,
+): Promise<T> {
+  return await withRepoMutationLock(repo, async () => {
+    const branch = await requireAllowedBranch(repo);
+    const result = await operation(branch);
+    const currentBranch = await getCurrentBranch(repo.worktreePath);
+
+    if (currentBranch !== branch) {
+      throw new BranchChangedDuringMutationError(branch, currentBranch || null, repo.worktreePath);
+    }
+
+    return result;
+  });
+}

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -58,6 +58,16 @@ export class DetachedHeadError extends Error {
   }
 }
 
+export class BranchChangedDuringMutationError extends Error {
+  constructor(expectedBranch: string, actualBranch: string | null, repoPath: string) {
+    const actualSummary = actualBranch ? `'${actualBranch}'` : "detached HEAD";
+    super(
+      `repository '${repoPath}' changed branches during the mutation: expected '${expectedBranch}', found ${actualSummary}; rerun the tool after restoring the authorized branch`,
+    );
+    this.name = "BranchChangedDuringMutationError";
+  }
+}
+
 export class PathValidationError extends Error {
   constructor(message: string) {
     super(message);

--- a/src/server.ts
+++ b/src/server.ts
@@ -4,7 +4,7 @@ import { z } from "zod";
 
 import { bootstrapConfig, loadOptionalConfig, upsertRepoConfig } from "./config.js";
 import { ConfigError, RepoNotAllowedError } from "./errors.js";
-import { requireAllowedBranch } from "./auth/branchAuth.js";
+import { withAllowedBranchMutation, withRepoMutationLock } from "./auth/repoMutation.js";
 import { requireTrustedRepoPolicy } from "./auth/repoPolicyTrust.js";
 import { resolveAllowedRepo } from "./auth/repoAuth.js";
 import { gitAdd } from "./tools/gitAdd.js";
@@ -201,8 +201,7 @@ export function createServer(configPath: string): McpServer {
     CLOSED_WORLD_ADDITIVE_MUTATION_TOOL,
     async ({ repo_path, message }) => {
       const repo = await resolveRuntimeRepo(configPath, repo_path);
-      await requireAllowedBranch(repo);
-      const result = await gitCommit(repo, message);
+      const result = await withAllowedBranchMutation(repo, async () => await gitCommit(repo, message));
 
       return {
         content: [
@@ -226,7 +225,9 @@ export function createServer(configPath: string): McpServer {
     CLOSED_WORLD_POTENTIALLY_DESTRUCTIVE_MUTATION_TOOL,
     async ({ repo_path, new_branch, branch }) => {
       const repo = await resolveRuntimeRepo(configPath, repo_path);
-      const result = await gitBranchCreateAndSwitch(repo, { newBranch: new_branch, branch });
+      const result = await withRepoMutationLock(repo, async () =>
+        await gitBranchCreateAndSwitch(repo, { newBranch: new_branch, branch }),
+      );
 
       return {
         content: [
@@ -249,7 +250,7 @@ export function createServer(configPath: string): McpServer {
     CLOSED_WORLD_POTENTIALLY_DESTRUCTIVE_MUTATION_TOOL,
     async ({ repo_path, branch }) => {
       const repo = await resolveRuntimeRepo(configPath, repo_path);
-      const result = await gitBranchSwitch(repo, branch);
+      const result = await withRepoMutationLock(repo, async () => await gitBranchSwitch(repo, branch));
 
       return {
         content: [
@@ -272,7 +273,7 @@ export function createServer(configPath: string): McpServer {
     CLOSED_WORLD_ADDITIVE_MUTATION_TOOL,
     async ({ repo_path, branch }) => {
       const repo = await resolveRuntimeRepo(configPath, repo_path);
-      const result = await gitFetch(repo, { branch });
+      const result = await withRepoMutationLock(repo, async () => await gitFetch(repo, { branch }));
 
       return {
         content: [
@@ -294,7 +295,7 @@ export function createServer(configPath: string): McpServer {
     CLOSED_WORLD_POTENTIALLY_DESTRUCTIVE_MUTATION_TOOL,
     async ({ repo_path }) => {
       const repo = await resolveRuntimeRepo(configPath, repo_path);
-      const result = await gitSyncBase(repo);
+      const result = await withAllowedBranchMutation(repo, async () => await gitSyncBase(repo));
 
       return {
         content: [
@@ -316,7 +317,7 @@ export function createServer(configPath: string): McpServer {
     CLOSED_WORLD_POTENTIALLY_DESTRUCTIVE_MUTATION_TOOL,
     async ({ repo_path }) => {
       const repo = await resolveRuntimeRepo(configPath, repo_path);
-      const result = await gitPullCurrentBranch(repo);
+      const result = await withAllowedBranchMutation(repo, async () => await gitPullCurrentBranch(repo));
 
       return {
         content: [
@@ -341,7 +342,9 @@ export function createServer(configPath: string): McpServer {
     CLOSED_WORLD_ADDITIVE_MUTATION_TOOL,
     async ({ repo_path, path, new_branch, branch }) => {
       const repo = await resolveRuntimeRepo(configPath, repo_path);
-      const result = await gitWorktreeAdd(repo, { path, newBranch: new_branch, branch });
+      const result = await withRepoMutationLock(repo, async () =>
+        await gitWorktreeAdd(repo, { path, newBranch: new_branch, branch }),
+      );
 
       return {
         content: [
@@ -363,8 +366,7 @@ export function createServer(configPath: string): McpServer {
     CLOSED_WORLD_ADDITIVE_MUTATION_TOOL,
     async ({ repo_path }) => {
       const repo = await resolveRuntimeRepo(configPath, repo_path);
-      const branch = await requireAllowedBranch(repo);
-      const result = await gitPush(repo, branch);
+      const result = await withAllowedBranchMutation(repo, async (branch) => await gitPush(repo, branch));
 
       return {
         content: [
@@ -389,8 +391,9 @@ export function createServer(configPath: string): McpServer {
     CLOSED_WORLD_ADDITIVE_MUTATION_TOOL,
     async ({ repo_path, title, body, base }) => {
       const repo = await resolveRuntimeRepo(configPath, repo_path);
-      const branch = await requireAllowedBranch(repo);
-      const result = await ghPrCreateDraft(repo, branch, { title, body, base });
+      const result = await withAllowedBranchMutation(repo, async (branch) =>
+        await ghPrCreateDraft(repo, branch, { title, body, base }),
+      );
 
       return {
         content: [
@@ -422,8 +425,7 @@ function registerGitAddLikeTool(server: McpServer, configPath: string, toolName:
     CLOSED_WORLD_ADDITIVE_MUTATION_TOOL,
     async ({ repo_path, paths }) => {
       const repo = await resolveRuntimeRepo(configPath, repo_path);
-      await requireAllowedBranch(repo);
-      const result = await gitAdd(repo, paths);
+      const result = await withAllowedBranchMutation(repo, async () => await gitAdd(repo, paths));
 
       return {
         content: [

--- a/tests/repoMutation.test.ts
+++ b/tests/repoMutation.test.ts
@@ -1,0 +1,72 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { BranchChangedDuringMutationError } from "../src/errors.js";
+import { getCurrentBranch, switchBranch } from "../src/exec/git.js";
+import { runCommand } from "../src/exec/run.js";
+import { withAllowedBranchMutation, withRepoMutationLock } from "../src/auth/repoMutation.js";
+import { createTempGitRepo } from "./helpers.js";
+
+const tempPaths: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempPaths.splice(0).map((tempPath) => fs.rm(tempPath, { force: true, recursive: true })));
+});
+
+describe("withAllowedBranchMutation", () => {
+  it("fails when the current branch changes before the mutation completes", async () => {
+    const { repoDir, repo } = await createTempGitRepo();
+    tempPaths.push(repoDir);
+
+    await fs.writeFile(path.join(repoDir, "README.md"), "hello\n", "utf8");
+    await runCommand({ cwd: repoDir, command: "git", argv: ["add", "README.md"] });
+    await runCommand({ cwd: repoDir, command: "git", argv: ["commit", "-m", "initial"] });
+    await runCommand({ cwd: repoDir, command: "git", argv: ["branch", "feature/other"] });
+
+    await expect(
+      withAllowedBranchMutation(repo, async () => {
+        await switchBranch(repo.worktreePath, "feature/other");
+        return { changed: true };
+      }),
+    ).rejects.toEqual(new BranchChangedDuringMutationError("main", "feature/other", repo.worktreePath));
+  });
+});
+
+describe("withRepoMutationLock", () => {
+  it("serializes mutations that target the same worktree", async () => {
+    const { repoDir, repo } = await createTempGitRepo();
+    tempPaths.push(repoDir);
+
+    const events: string[] = [];
+    let releaseFirst!: () => void;
+    const firstBlocked = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    let markFirstStarted!: () => void;
+    const firstStarted = new Promise<void>((resolve) => {
+      markFirstStarted = resolve;
+    });
+
+    const first = withRepoMutationLock(repo, async () => {
+      events.push("first:start");
+      markFirstStarted();
+      await firstBlocked;
+      events.push("first:end");
+    });
+
+    const second = withRepoMutationLock(repo, async () => {
+      events.push("second:start");
+      events.push(`second:branch:${await getCurrentBranch(repo.worktreePath)}`);
+    });
+
+    await firstStarted;
+    expect(events).toEqual(["first:start"]);
+
+    releaseFirst();
+    await Promise.all([first, second]);
+
+    expect(events).toEqual(["first:start", "first:end", "second:start", "second:branch:main"]);
+  });
+});


### PR DESCRIPTION
## Why
The mutating handlers were authorizing the current branch and then performing the Git or GitHub operation later, which left a TOCTOU gap inside a single MCP server process. A concurrent mutation in the same worktree could switch branches in between and let the tool report success against a different branch than the one that was authorized. This change adds a process-local per-worktree mutation queue and re-checks the current branch before returning success from allowed-branch mutations, so branch drift becomes an explicit error instead of a silent success.

Fixes #59.

## Impact
Mutating repository tools now serialize per worktree within the MCP process, and branch-authorized mutations fail closed if the branch changed while the operation was running. The remaining limitation is explicit: a different external process can still mutate the worktree concurrently, but the MCP call will no longer report a clean success after branch drift. The new regression tests cover both the branch-change detection and the per-worktree serialization behavior.