### PR TITLE
Document config mutation trust model

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ If that file does not exist yet, the server still starts and exposes the full to
 
 `config_bootstrap` and `config_upsert_repo` can still create or update the YAML when you want an external allowlist.
 
+### Configuration trust model
+
+`config_bootstrap` and `config_upsert_repo` are administrative conveniences, not security controls. A caller that can invoke them can create or widen repository policy, and runtime tools will use the changed policy on their next call. Hosts should expose these tools only to trusted callers; otherwise, omit them from the available tool set or require host-side approval for each invocation.
+
 Example:
 
 ```yaml
@@ -368,6 +372,8 @@ repositories:
 ```
 
 If you want to bootstrap the config and then add this repository incrementally, a minimal progression is:
+
+Use this progression only when the caller is trusted to change MCP policy. Exposing either configuration mutation tool delegates that authority to its caller.
 
 1. Call `config_bootstrap` with defaults such as `feature_branch_pattern`, the preferred `workflow_mode`, or `allowed_workflow_modes`.
 2. Call `config_upsert_repo` with `repo_path`, and optionally `git_worktree_base_path`, `default_remote`, `allowed_branch_patterns`, the preferred `workflow_mode`, or `allowed_workflow_modes`.


### PR DESCRIPTION
## Why

Configuration mutation tools can create or widen repository policy, and runtime tools reload that policy on their next call. This is intentional administrative behavior rather than a security boundary, but the README did not make that trust model explicit enough for hosts deciding which tools to expose.

This change documents that callers with access to `config_bootstrap` or `config_upsert_repo` are trusted to change MCP policy and directs hosts to omit or approval-gate those tools otherwise.

## Impact

Hosts get explicit guidance for deciding whether configuration mutation tools belong in an agent's available tool set. Runtime behavior and tool contracts remain unchanged.

The underlying limitation remains: exposing either configuration mutation tool delegates policy-change authority to its caller.

## Validation

- `npm test` (22 files, 135 tests passed)
- `npm run typecheck`
- `npm run build`

Closes #58