### PR TITLE
docs: document stable SSH agent sockets

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,49 @@ export SSH_AUTH_SOCK=/path/to/ssh-agent.sock
 
 On macOS, the wrapper will also try `launchctl getenv SSH_AUTH_SOCK` before failing.
 
+For GUI-launched Codex on macOS, a stable SSH agent socket is usually more reliable than the system `SSH_AUTH_SOCK`. The system socket can be dynamic, and `launchctl setenv` values do not survive a reboot. If you use an agent with a stable socket, configure the MCP server with that socket explicitly.
+
+For example, 1Password's SSH agent exposes this socket on macOS:
+
+```text
+/Users/<user>/Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock
+```
+
+Add the socket to your Codex config:
+
+```toml
+[mcp_servers.git_unleash.env]
+SSH_AUTH_SOCK = "/Users/<user>/Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock"
+GIT_UNLEASH_SSH_AUTH_SOCK = "/Users/<user>/Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock"
+```
+
+Then verify that the agent exposes the key Git is configured to use for SSH signing:
+
+```bash
+SSH_AUTH_SOCK="/Users/<user>/Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock" ssh-add -L
+git config --get user.signingkey
+```
+
+The public key shown by `ssh-add -L` must match the public key configured by `user.signingkey`. The comments may differ, but the key type and key body must match.
+
+If you use Apple's built-in SSH agent and Keychain integration, keep in mind that this SSH config:
+
+```sshconfig
+Host *
+    AddKeysToAgent yes
+    UseKeychain yes
+    IdentityFile ~/.ssh/id_ed25519
+```
+
+does not necessarily load identities into the agent at login. It can be lazy and load the key only after an SSH operation runs. That means a preflight like `ssh-add -L` can still report no identities immediately after a reboot. In that setup, either load the key before starting Codex or use a stable agent socket such as 1Password, Secretive, or another dedicated SSH agent.
+
+Troubleshooting checklist:
+
+- If startup fails with `SSH_AUTH_SOCK is not set`, the MCP host did not pass a socket and the wrapper could not recover one through `GIT_UNLEASH_SSH_AUTH_SOCK` or `launchctl getenv SSH_AUTH_SOCK`.
+- If startup fails with `ssh-agent is reachable ... but it is not returning any identities`, the socket is valid but `ssh-add -L` cannot see a loaded key.
+- If Terminal Git works but MCP startup fails after reboot, check whether Terminal lazily loaded the key after the MCP server had already started.
+- If you use a stable agent socket, prefer setting both `SSH_AUTH_SOCK` and `GIT_UNLEASH_SSH_AUTH_SOCK` in the MCP server config so the wrapper and child Git processes agree on the same agent.
+
 If you need an exact PATH instead of the built-in fallback behavior, you can still register the server with an explicit environment override:
 
 ```bash


### PR DESCRIPTION
## Why

Codex can launch MCP servers from a GUI environment that does not inherit an interactive shell's dynamic `SSH_AUTH_SOCK`. On macOS this is especially confusing after reboot: the system socket can be dynamic, `launchctl setenv` values are not persistent, and Apple Keychain-backed SSH config may lazily load identities only after an SSH operation runs.

This documents the more stable setup we validated: point `git_unleash` at a stable SSH agent socket such as 1Password's macOS SSH agent socket.

## Impact

Good:
- Adds a concrete 1Password socket example for `~/.codex/config.toml`.
- Explains how to verify that the exposed key matches Git's SSH signing key.
- Adds troubleshooting notes for missing sockets and empty agents.

Potentially bad:
- The 1Password path is macOS-specific and users on other platforms or agents need to substitute their own stable socket path.

## Verification

- `npm run typecheck`