### PR TITLE
Share prospective path canonicalization

### DIFF
--- a/src/auth/pathValidation.ts
+++ b/src/auth/pathValidation.ts
@@ -1,7 +1,7 @@
-import fs from "node:fs/promises";
 import path from "node:path";
 
 import { PathValidationError } from "../errors.js";
+import { canonicalizeProspectivePath } from "../pathCanonicalization.js";
 
 export function validateRepoRelativePaths(repoRoot: string, inputPaths: string[]): string[] {
   if (inputPaths.length === 0) {
@@ -21,7 +21,7 @@ export async function validateWorktreePath(inputPath: string): Promise<string> {
   }
 
   const resolvedPath = path.resolve(inputPath);
-  const canonicalWorktreePath = await canonicalizeProspectivePath(resolvedPath);
+  const canonicalWorktreePath = await canonicalizeProspectiveWorktreePath(resolvedPath);
 
   return canonicalWorktreePath;
 }
@@ -36,7 +36,7 @@ export async function validateWorktreePathAgainstBasePath(
     return canonicalWorktreePath;
   }
 
-  const canonicalBasePath = await canonicalizeProspectivePath(path.resolve(basePath));
+  const canonicalBasePath = await canonicalizeProspectiveWorktreePath(path.resolve(basePath));
   const relativeToBase = path.relative(canonicalBasePath, canonicalWorktreePath);
   if (
     relativeToBase === ".." ||
@@ -83,22 +83,8 @@ function validateRepoRelativePath(repoRoot: string, inputPath: string): string {
   return relativeToRoot === "" ? "." : relativeToRoot;
 }
 
-async function canonicalizeProspectivePath(inputPath: string): Promise<string> {
-  const parts: string[] = [];
-  let currentPath = inputPath;
-
-  while (true) {
-    try {
-      const canonicalBase = await fs.realpath(currentPath);
-      return path.join(canonicalBase, ...parts.reverse());
-    } catch {
-      const parentPath = path.dirname(currentPath);
-      if (parentPath === currentPath) {
-        throw new PathValidationError(`worktree path '${inputPath}' could not be resolved`);
-      }
-
-      parts.push(path.basename(currentPath));
-      currentPath = parentPath;
-    }
-  }
+async function canonicalizeProspectiveWorktreePath(inputPath: string): Promise<string> {
+  return await canonicalizeProspectivePath(inputPath, (unresolvedPath) => {
+    return new PathValidationError(`worktree path '${unresolvedPath}' could not be resolved`);
+  });
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,6 +6,7 @@ import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
 import { z } from "zod";
 
 import { ConfigError } from "./errors.js";
+import { canonicalizeProspectivePath } from "./pathCanonicalization.js";
 import type { Config, RepoPolicy, RepoPolicyOverrides, WorkflowMode } from "./types/config.js";
 
 export const REPO_LOCAL_CONFIG_FILENAME = ".git-unleash.yaml";
@@ -496,33 +497,19 @@ async function resolveGitWorktreeBasePath(
   const expandedPath = expandHomeDir(inputPath);
   if (!path.isAbsolute(expandedPath)) {
     if (options.repoRoot) {
-      return await canonicalizeProspectivePath(path.resolve(options.repoRoot, expandedPath));
+      return await canonicalizeProspectiveConfigPath(path.resolve(options.repoRoot, expandedPath));
     }
 
     throw new ConfigError(`git_worktree_base_path '${inputPath}' must be absolute or start with '~/'`);
   }
 
-  return await canonicalizeProspectivePath(expandedPath);
+  return await canonicalizeProspectiveConfigPath(expandedPath);
 }
 
-async function canonicalizeProspectivePath(inputPath: string): Promise<string> {
-  const parts: string[] = [];
-  let currentPath = path.resolve(inputPath);
-
-  while (true) {
-    try {
-      const canonicalBase = await fs.realpath(currentPath);
-      return path.join(canonicalBase, ...parts.reverse());
-    } catch {
-      const parentPath = path.dirname(currentPath);
-      if (parentPath === currentPath) {
-        throw new ConfigError(`path '${inputPath}' could not be resolved`);
-      }
-
-      parts.push(path.basename(currentPath));
-      currentPath = parentPath;
-    }
-  }
+async function canonicalizeProspectiveConfigPath(inputPath: string): Promise<string> {
+  return await canonicalizeProspectivePath(inputPath, (unresolvedPath) => {
+    return new ConfigError(`path '${unresolvedPath}' could not be resolved`);
+  });
 }
 
 function compileBranchPatterns(patterns: string[], repoPath: string): RegExp[] {

--- a/src/pathCanonicalization.ts
+++ b/src/pathCanonicalization.ts
@@ -1,0 +1,25 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+export async function canonicalizeProspectivePath(
+  inputPath: string,
+  createUnresolvedPathError: (inputPath: string) => Error,
+): Promise<string> {
+  const parts: string[] = [];
+  let currentPath = path.resolve(inputPath);
+
+  while (true) {
+    try {
+      const canonicalBase = await fs.realpath(currentPath);
+      return path.join(canonicalBase, ...parts.reverse());
+    } catch {
+      const parentPath = path.dirname(currentPath);
+      if (parentPath === currentPath) {
+        throw createUnresolvedPathError(inputPath);
+      }
+
+      parts.push(path.basename(currentPath));
+      currentPath = parentPath;
+    }
+  }
+}

--- a/tests/pathCanonicalization.test.ts
+++ b/tests/pathCanonicalization.test.ts
@@ -1,0 +1,29 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { canonicalizeProspectivePath } from "../src/pathCanonicalization.js";
+
+const tempPaths: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempPaths.splice(0).map((tempPath) => fs.rm(tempPath, { force: true, recursive: true })));
+});
+
+describe("canonicalizeProspectivePath", () => {
+  it("resolves the existing parent and preserves the prospective path suffix", async () => {
+    const parentPath = await fs.mkdtemp(path.join(os.tmpdir(), "git-mcp-canonical-parent-"));
+    const linkContainerPath = await fs.mkdtemp(path.join(os.tmpdir(), "git-mcp-canonical-link-"));
+    const linkedParentPath = path.join(linkContainerPath, "parent-link");
+    await fs.symlink(parentPath, linkedParentPath);
+    tempPaths.push(parentPath, linkContainerPath);
+
+    await expect(
+      canonicalizeProspectivePath(path.join(linkedParentPath, "missing", "child"), (inputPath) => {
+        return new Error(`unresolved ${inputPath}`);
+      }),
+    ).resolves.toBe(path.join(await fs.realpath(parentPath), "missing", "child"));
+  });
+});


### PR DESCRIPTION
## Why

Issue #56 identified duplicated `canonicalizeProspectivePath()` traversal logic in `src/config.ts` and `src/auth/pathValidation.ts`. Keeping two copies makes future edge-case fixes easy to apply in only one place.

## What changed

- Added `src/pathCanonicalization.ts` with the shared upward `realpath()` traversal for prospective paths.
- Updated config parsing to map unresolved prospective paths to `ConfigError`.
- Updated worktree path validation to map unresolved prospective paths to `PathValidationError`.
- Added a focused unit test covering symlink canonicalization while preserving missing suffixes.

## Impact

The behavioral surface should stay the same: config code still throws config-oriented errors, and path validation still throws path-validation-oriented errors. The main risk is subtle path normalization drift, covered by existing config/path-validation tests plus the new shared-helper test.

## Verification

- RED: `npx vitest run tests/pathCanonicalization.test.ts` failed before the helper existed with missing `../src/pathCanonicalization.js`.
- `npm test`
- `npm run typecheck`
- `npm run build`

Closes #56