### PR TITLE
Validate repo-local default_remote at schema parse time

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -28,15 +28,25 @@ const repoPolicySchema = policyDefaultsSchema.extend({
   path: z.string().min(1),
 });
 
-const repoLocalPolicySchema = z.object({
-  allowed_branch_patterns: z.array(z.string().min(1)).nonempty(),
-  feature_branch_pattern: z.string().min(1).optional(),
-  git_worktree_base_path: z.string().min(1).optional(),
-  default_remote: z.string().min(1).optional(),
-  allow_draft_prs: z.boolean().optional(),
-  workflow_mode: workflowModeSchema.optional(),
-  allowed_workflow_modes: allowedWorkflowModesSchema.optional(),
-});
+const repoLocalPolicySchema = z
+  .object({
+    allowed_branch_patterns: z.array(z.string().min(1)).nonempty(),
+    feature_branch_pattern: z.string().min(1).optional(),
+    git_worktree_base_path: z.string().min(1).optional(),
+    default_remote: z.string().min(1).optional(),
+    allow_draft_prs: z.boolean().optional(),
+    workflow_mode: workflowModeSchema.optional(),
+    allowed_workflow_modes: allowedWorkflowModesSchema.optional(),
+  })
+  .superRefine((value, ctx) => {
+    if (value.default_remote !== undefined) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["default_remote"],
+        message: "repo-local config must not set default_remote",
+      });
+    }
+  });
 
 const configSchema = z.object({
   defaults: policyDefaultsSchema.optional(),
@@ -100,10 +110,6 @@ export async function loadRepoLocalPolicy(
     throw new ConfigError(
       `repo-local config '${configPath}' is invalid: ${error instanceof Error ? error.message : String(error)}`,
     );
-  }
-
-  if (parsed.default_remote !== undefined) {
-    throw new ConfigError(`repo-local config '${configPath}' must not set default_remote`);
   }
 
   const repoLocalPolicy: RepoPolicy = {

--- a/tests/repoAuth.test.ts
+++ b/tests/repoAuth.test.ts
@@ -333,7 +333,17 @@ describe("resolveAllowedRepo", () => {
     );
 
     await expect(resolveAllowedRepo({ repositories: [] }, repoDir)).rejects.toEqual(
-      new ConfigError(`repo-local config '${path.join(await fs.realpath(repoDir), ".git-unleash.yaml")}' must not set default_remote`),
+      new ConfigError(
+        `repo-local config '${path.join(await fs.realpath(repoDir), ".git-unleash.yaml")}' is invalid: [\n` +
+          '  {\n' +
+          '    "code": "custom",\n' +
+          '    "path": [\n' +
+          '      "default_remote"\n' +
+          "    ],\n" +
+          '    "message": "repo-local config must not set default_remote"\n' +
+          "  }\n" +
+          "]",
+      ),
     );
   });
 


### PR DESCRIPTION
Why

Issue #55 points out that repo-local policy currently accepts `default_remote` structurally in `repoLocalPolicySchema` and only rejects it later with an imperative guard. That splits one rule across two layers and makes the schema less self-descriptive than it should be.

This change moves the restriction into schema validation itself, so repo-local policy parsing fails at the point where the invalid field is encountered. The follow-up imperative check is removed because the schema now owns that rule.

Impact

This makes repo-local policy validation more declarative and keeps the invalid `default_remote` rule in one place, which should make future config changes easier to reason about. The main behavior change is the error surfacing path: the rejection now comes from schema validation and is wrapped as an invalid repo-local config error, so any callers or tests that depended on the old imperative message need to follow the new validation output.

Closes #55