### PR TITLE
Avoid live fetch for repo-local policy trust checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,8 @@ Repo-local policy rules:
 - global config still works as a fallback when a repository does not define `.git-unleash.yaml`
 - for repo-local policy, `git_worktree_base_path` may be relative to the repository root
 - repo-local policy must not set `default_remote`
-- runtime tools fetch the trusted base branch of the current repository instance, compare the repo-local policy in base, index, and working tree, and fail closed on any divergence
+- runtime tools compare the repo-local policy in the local remote-tracking base ref, index, and working tree, and fail closed on any divergence
+- when the trusted base copy is missing locally, runtime tools fetch that base branch and retry the trust check before failing closed
 - in a fork, the fork's own base branch is authoritative for repo-local policy
 - this prevents locally widened repo-local policy from being used for MCP operations
 

--- a/src/auth/repoPolicyTrust.ts
+++ b/src/auth/repoPolicyTrust.ts
@@ -19,17 +19,19 @@ export async function requireTrustedRepoPolicy(repo: RepoPolicy): Promise<void> 
   }
 
   const remote = await resolveRepoRemote(repo, { allowConfiguredDefaultRemote: false });
-  const base = await resolveRepoBaseBranch(repo, remote);
-
-  await fetchBranch(repo.worktreePath, remote, base);
+  const base = await resolveRepoBaseBranch(repo, remote, { preferLocal: true });
 
   const baseSpec = `refs/remotes/${remote}/${base}:${relativeConfigPath}`;
   const indexSpec = `:${relativeConfigPath}`;
 
-  const [baseOid, indexOid] = await Promise.all([
-    getTrustedPolicyObjectId(repo.worktreePath, baseSpec, repo, configPath, `it is missing from ${remote}/${base}`),
-    getTrustedPolicyObjectId(repo.worktreePath, indexSpec, repo, configPath, "it is missing from the index"),
-  ]);
+  const baseOid = await getTrustedPolicyBaseObjectId(repo.worktreePath, baseSpec, repo, configPath, remote, base);
+  const indexOid = await getTrustedPolicyObjectId(
+    repo.worktreePath,
+    indexSpec,
+    repo,
+    configPath,
+    "it is missing from the index",
+  );
 
   if (baseOid !== indexOid) {
     throw new RepoLocalPolicyNotTrustedError(
@@ -45,6 +47,22 @@ export async function requireTrustedRepoPolicy(repo: RepoPolicy): Promise<void> 
       configPath,
       "the working tree copy differs from the staged repo-local policy",
     );
+  }
+}
+
+async function getTrustedPolicyBaseObjectId(
+  cwd: string,
+  baseSpec: string,
+  repo: RepoPolicy,
+  configPath: string,
+  remote: string,
+  base: string,
+): Promise<string> {
+  try {
+    return await getVerifiedObjectId(cwd, baseSpec);
+  } catch {
+    await fetchBranch(cwd, remote, base);
+    return await getTrustedPolicyObjectId(cwd, baseSpec, repo, configPath, `it is missing from ${remote}/${base}`);
   }
 }
 

--- a/src/exec/git.ts
+++ b/src/exec/git.ts
@@ -54,6 +54,10 @@ export function gitRemoteHeadArgs(remote: string): string[] {
   return ["ls-remote", "--symref", remote, "HEAD"];
 }
 
+export function gitRemoteTrackingHeadArgs(remote: string): string[] {
+  return ["symbolic-ref", "--short", `refs/remotes/${remote}/HEAD`];
+}
+
 export function gitRevParseVerifyArgs(spec: string): string[] {
   return ["rev-parse", "--verify", spec];
 }
@@ -242,6 +246,21 @@ export async function getRemoteHeadBranch(cwd: string, remote: string): Promise<
 
     const match = /^ref:\s+refs\/heads\/(.+)\s+HEAD$/.exec(headLine);
     return match?.[1] ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export async function getLocalRemoteHeadBranch(cwd: string, remote: string): Promise<string | null> {
+  try {
+    const result = await runCommand({
+      cwd,
+      command: "git",
+      argv: gitRemoteTrackingHeadArgs(remote),
+    });
+    const shortRef = result.stdout.trim();
+    const prefix = `${remote}/`;
+    return shortRef.startsWith(prefix) ? shortRef.slice(prefix.length) : null;
   } catch {
     return null;
   }

--- a/src/tools/runtimeDefaults.ts
+++ b/src/tools/runtimeDefaults.ts
@@ -3,6 +3,7 @@ import { getRepoDefaultBranch } from "../exec/gh.js";
 import {
   getBranchRemote,
   getCurrentBranch,
+  getLocalRemoteHeadBranch,
   getRemoteHeadBranch,
   remoteExists,
 } from "../exec/git.js";
@@ -35,7 +36,18 @@ export async function resolveRepoRemote(
   throw new RemoteResolutionError(repo.worktreePath);
 }
 
-export async function resolveRepoBaseBranch(repo: RepoPolicy, remote: string): Promise<string> {
+export async function resolveRepoBaseBranch(
+  repo: RepoPolicy,
+  remote: string,
+  options: { preferLocal?: boolean } = {},
+): Promise<string> {
+  if (options.preferLocal) {
+    const localRemoteHeadBranch = await getLocalRemoteHeadBranch(repo.worktreePath, remote);
+    if (localRemoteHeadBranch) {
+      return localRemoteHeadBranch;
+    }
+  }
+
   const remoteHeadBranch = await getRemoteHeadBranch(repo.worktreePath, remote);
   if (remoteHeadBranch) {
     return remoteHeadBranch;

--- a/tests/repoPolicyTrust.local-first.test.ts
+++ b/tests/repoPolicyTrust.local-first.test.ts
@@ -1,0 +1,110 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { RepoLocalPolicyNotTrustedError } from "../src/errors.js";
+import type { RepoPolicy } from "../src/types/config.js";
+
+const {
+  fetchBranch,
+  getVerifiedObjectId,
+  hasWorkingTreeChanges,
+} = vi.hoisted(() => ({
+  fetchBranch: vi.fn(),
+  getVerifiedObjectId: vi.fn(),
+  hasWorkingTreeChanges: vi.fn(),
+}));
+
+const {
+  resolveRepoBaseBranch,
+  resolveRepoRemote,
+} = vi.hoisted(() => ({
+  resolveRepoBaseBranch: vi.fn(),
+  resolveRepoRemote: vi.fn(),
+}));
+
+vi.mock("../src/exec/git.js", () => ({
+  fetchBranch,
+  getVerifiedObjectId,
+  hasWorkingTreeChanges,
+}));
+
+vi.mock("../src/tools/runtimeDefaults.js", () => ({
+  resolveRepoBaseBranch,
+  resolveRepoRemote,
+}));
+
+const { requireTrustedRepoPolicy } = await import("../src/auth/repoPolicyTrust.js");
+
+const repo: RepoPolicy = {
+  path: "/tmp/repo",
+  canonicalPath: "/tmp/repo",
+  worktreePath: "/tmp/repo",
+  allowedBranchPatterns: [/^dm\/.*$/],
+  allowDraftPrs: true,
+  policySource: "repo_local",
+  repoLocalConfigPath: "/tmp/repo/.git-unleash.yaml",
+  repoLocalConfigRelativePath: ".git-unleash.yaml",
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  fetchBranch.mockReset();
+  getVerifiedObjectId.mockReset();
+  hasWorkingTreeChanges.mockReset();
+  resolveRepoBaseBranch.mockReset();
+  resolveRepoRemote.mockReset();
+});
+
+describe("requireTrustedRepoPolicy local-first trust checks", () => {
+  it("uses the local trusted base copy without fetching when it is already available", async () => {
+    resolveRepoRemote.mockResolvedValue("origin");
+    resolveRepoBaseBranch.mockResolvedValue("main");
+    getVerifiedObjectId.mockResolvedValue("same-oid");
+    hasWorkingTreeChanges.mockResolvedValue(false);
+
+    await expect(requireTrustedRepoPolicy(repo)).resolves.toBeUndefined();
+
+    expect(resolveRepoRemote).toHaveBeenCalledWith(repo, { allowConfiguredDefaultRemote: false });
+    expect(resolveRepoBaseBranch).toHaveBeenCalledWith(repo, "origin", { preferLocal: true });
+    expect(fetchBranch).not.toHaveBeenCalled();
+    expect(getVerifiedObjectId).toHaveBeenNthCalledWith(
+      1,
+      "/tmp/repo",
+      "refs/remotes/origin/main:.git-unleash.yaml",
+    );
+    expect(getVerifiedObjectId).toHaveBeenNthCalledWith(2, "/tmp/repo", ":.git-unleash.yaml");
+  });
+
+  it("fetches the trusted base branch only after a local remote-tracking miss", async () => {
+    resolveRepoRemote.mockResolvedValue("origin");
+    resolveRepoBaseBranch.mockResolvedValue("main");
+    getVerifiedObjectId
+      .mockRejectedValueOnce(new Error("missing local remote-tracking blob"))
+      .mockResolvedValueOnce("same-oid")
+      .mockResolvedValueOnce("same-oid");
+    hasWorkingTreeChanges.mockResolvedValue(false);
+
+    await expect(requireTrustedRepoPolicy(repo)).resolves.toBeUndefined();
+
+    expect(fetchBranch).toHaveBeenCalledWith("/tmp/repo", "origin", "main");
+    expect(getVerifiedObjectId).toHaveBeenNthCalledWith(
+      1,
+      "/tmp/repo",
+      "refs/remotes/origin/main:.git-unleash.yaml",
+    );
+    expect(getVerifiedObjectId).toHaveBeenNthCalledWith(
+      2,
+      "/tmp/repo",
+      "refs/remotes/origin/main:.git-unleash.yaml",
+    );
+    expect(getVerifiedObjectId).toHaveBeenNthCalledWith(3, "/tmp/repo", ":.git-unleash.yaml");
+  });
+
+  it("still fails closed when the trusted base copy is unavailable after fetch", async () => {
+    resolveRepoRemote.mockResolvedValue("origin");
+    resolveRepoBaseBranch.mockResolvedValue("main");
+    getVerifiedObjectId.mockRejectedValue(new Error("still missing"));
+
+    await expect(requireTrustedRepoPolicy(repo)).rejects.toBeInstanceOf(RepoLocalPolicyNotTrustedError);
+    expect(fetchBranch).toHaveBeenCalledWith("/tmp/repo", "origin", "main");
+  });
+});

--- a/tests/runtimeDefaults.test.ts
+++ b/tests/runtimeDefaults.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { BaseBranchResolutionError } from "../src/errors.js";
+import type { RepoPolicy } from "../src/types/config.js";
+import { resolveRepoBaseBranch } from "../src/tools/runtimeDefaults.js";
+
+const {
+  getLocalRemoteHeadBranch,
+  getRemoteHeadBranch,
+} = vi.hoisted(() => ({
+  getLocalRemoteHeadBranch: vi.fn(),
+  getRemoteHeadBranch: vi.fn(),
+}));
+
+const { getRepoDefaultBranch } = vi.hoisted(() => ({
+  getRepoDefaultBranch: vi.fn(),
+}));
+
+vi.mock("../src/exec/git.js", async () => {
+  const actual = await vi.importActual<typeof import("../src/exec/git.js")>("../src/exec/git.js");
+  return {
+    ...actual,
+    getLocalRemoteHeadBranch,
+    getRemoteHeadBranch,
+  };
+});
+
+vi.mock("../src/exec/gh.js", () => ({
+  getRepoDefaultBranch,
+}));
+
+const repo: RepoPolicy = {
+  path: "/tmp/repo",
+  canonicalPath: "/tmp/repo",
+  worktreePath: "/tmp/repo",
+  allowedBranchPatterns: [/^dm\/.*$/],
+  allowDraftPrs: true,
+  policySource: "global",
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  getLocalRemoteHeadBranch.mockReset();
+  getRemoteHeadBranch.mockReset();
+  getRepoDefaultBranch.mockReset();
+});
+
+describe("resolveRepoBaseBranch", () => {
+  it("prefers the local remote-tracking HEAD when requested", async () => {
+    getLocalRemoteHeadBranch.mockResolvedValue("main");
+
+    await expect(resolveRepoBaseBranch(repo, "origin", { preferLocal: true })).resolves.toBe("main");
+
+    expect(getLocalRemoteHeadBranch).toHaveBeenCalledWith("/tmp/repo", "origin");
+    expect(getRemoteHeadBranch).not.toHaveBeenCalled();
+    expect(getRepoDefaultBranch).not.toHaveBeenCalled();
+  });
+
+  it("falls back to remote HEAD and then GitHub default branch when the local ref is unavailable", async () => {
+    getLocalRemoteHeadBranch.mockResolvedValue(null);
+    getRemoteHeadBranch.mockResolvedValue(null);
+    getRepoDefaultBranch.mockResolvedValue("trunk");
+
+    await expect(resolveRepoBaseBranch(repo, "origin", { preferLocal: true })).resolves.toBe("trunk");
+
+    expect(getLocalRemoteHeadBranch).toHaveBeenCalledWith("/tmp/repo", "origin");
+    expect(getRemoteHeadBranch).toHaveBeenCalledWith("/tmp/repo", "origin");
+    expect(getRepoDefaultBranch).toHaveBeenCalledWith("/tmp/repo");
+  });
+
+  it("raises the existing resolution error when no local or remote default branch can be determined", async () => {
+    getLocalRemoteHeadBranch.mockResolvedValue(null);
+    getRemoteHeadBranch.mockResolvedValue(null);
+    getRepoDefaultBranch.mockResolvedValue(null);
+
+    await expect(resolveRepoBaseBranch(repo, "origin", { preferLocal: true })).rejects.toBeInstanceOf(
+      BaseBranchResolutionError,
+    );
+  });
+});


### PR DESCRIPTION
## Why
Repo-local policy trust checks currently resolve the base branch through live remote lookups and fetch the base branch on every mutating tool call. That keeps the trust model conservative, but it also makes ordinary local mutations like `git_add` and `git_commit` fail when network access or remote/default-branch resolution is unavailable.

This change keeps the fail-closed integrity check while narrowing when network access is required. Trust validation now prefers the local remote-tracking base ref and the locally available trusted policy blob, and only fetches the base branch when that trusted copy is missing locally.

## Impact
Positive: ordinary repo-local-policy mutations no longer require a live fetch when the trusted base copy already exists in local remote-tracking refs, so local workflows are less fragile offline or during remote-resolution issues.

Potentially bad: if the local remote-tracking base ref is stale, the trust check can temporarily rely on that stale trusted copy until the next fetch-triggering miss or explicit fetch updates it. The implementation still fails closed on divergence and still fetches when the local trusted base copy is unavailable.

Closes #53