### PR TITLE
Pre-compile full-match branch regexes

### DIFF
--- a/src/auth/branchAuth.ts
+++ b/src/auth/branchAuth.ts
@@ -2,8 +2,6 @@ import { BranchNameNotAllowedError, BranchNotAllowedError, DetachedHeadError } f
 import { getCurrentBranch } from "../exec/git.js";
 import type { RepoPolicy } from "../types/config.js";
 
-const fullMatchCache = new WeakMap<RegExp, RegExp>();
-
 export async function requireAllowedBranch(repo: RepoPolicy): Promise<string> {
   const branch = await getCurrentBranch(repo.worktreePath);
   if (!branch) {
@@ -30,12 +28,6 @@ export function isAllowedBranchName(repo: RepoPolicy, branch: string): boolean {
 }
 
 export function fullMatch(pattern: RegExp, value: string): boolean {
-  let fullPattern = fullMatchCache.get(pattern);
-  if (!fullPattern) {
-    fullPattern = new RegExp(`^(?:${pattern.source})$`, pattern.flags);
-    fullMatchCache.set(pattern, fullPattern);
-  }
-
-  fullPattern.lastIndex = 0;
-  return fullPattern.test(value);
+  pattern.lastIndex = 0;
+  return pattern.test(value);
 }

--- a/src/auth/branchAuth.ts
+++ b/src/auth/branchAuth.ts
@@ -28,6 +28,8 @@ export function isAllowedBranchName(repo: RepoPolicy, branch: string): boolean {
 }
 
 export function fullMatch(pattern: RegExp, value: string): boolean {
-  pattern.lastIndex = 0;
-  return pattern.test(value);
+  // We intentionally clone here instead of mutating RegExp.lastIndex in place.
+  // This adds negligible overhead on our git-tool paths and keeps matching free
+  // of shared mutable regex state even though issue #48 optimized for reuse.
+  return new RegExp(pattern.source, pattern.flags).test(value);
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -525,7 +525,7 @@ function compileBranchPatterns(patterns: string[], repoPath: string): RegExp[] {
     validateSafeBranchPattern(resolvedPattern, repoPath);
 
     try {
-      return new RegExp(resolvedPattern);
+      return new RegExp(`^(?:${resolvedPattern})$`);
     } catch (error) {
       throw new ConfigError(
         `invalid branch regex '${resolvedPattern}' for repository '${repoPath}': ${

--- a/tests/branchAuth.test.ts
+++ b/tests/branchAuth.test.ts
@@ -8,11 +8,11 @@ describe("fullMatch", () => {
   });
 
   it("does not match only a substring", () => {
-    expect(fullMatch(/feature\/[a-z0-9._-]+/, "x/feature/test-1")).toBe(false);
+    expect(fullMatch(/^(?:feature\/[a-z0-9._-]+)$/, "x/feature/test-1")).toBe(false);
   });
 
   it("resets cached global regex state between calls", () => {
-    const pattern = /feature\/[a-z0-9._-]+/g;
+    const pattern = /^(?:feature\/[a-z0-9._-]+)$/g;
 
     expect(fullMatch(pattern, "feature/test-1")).toBe(true);
     expect(fullMatch(pattern, "feature/test-1")).toBe(true);

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -37,7 +37,28 @@ describe("loadConfig", () => {
      expect(config.repositories[0]?.allowDraftPrs).toBe(true);
      expect(config.repositories[0]?.featureBranchPattern).toBeUndefined();
      expect(config.repositories[0]?.workflowMode).toBeUndefined();
-    expect(config.repositories[0]?.allowedBranchPatterns.map((pattern) => pattern.source)).toEqual(["^feature\\/.+$"]);
+    expect(config.repositories[0]?.allowedBranchPatterns.map((pattern) => pattern.source)).toEqual([
+      "^(?:^feature\\/.+$)$",
+    ]);
+  });
+
+  it("pre-compiles allowed branch patterns as full-match regexes", async () => {
+    const repoDir = await fs.mkdtemp(path.join(os.tmpdir(), "git-mcp-anchored-pattern-repo-"));
+    const configPath = path.join(os.tmpdir(), `git-mcp-config-${Date.now()}-anchored-pattern.yaml`);
+    tempPaths.push(repoDir, configPath);
+
+    await fs.writeFile(
+      configPath,
+      `repositories:\n  - path: ${repoDir}\n    allowed_branch_patterns:\n      - "feature/[a-z0-9._-]+"\n`,
+      "utf8",
+    );
+
+    const config = await loadConfig(configPath);
+    const [pattern] = config.repositories[0]?.allowedBranchPatterns ?? [];
+
+    expect(pattern?.source).toBe("^(?:feature\\/[a-z0-9._-]+)$");
+    expect(pattern?.test("feature/test-1")).toBe(true);
+    expect(pattern?.test("x/feature/test-1")).toBe(false);
   });
 
   it("inherits top-level defaults", async () => {
@@ -65,7 +86,9 @@ describe("loadConfig", () => {
     const config = await loadConfig(configPath);
     const expectedBasePath = path.join(os.homedir(), "git-worktrees");
 
-     expect(config.repositories[0]?.allowedBranchPatterns.map((pattern) => pattern.source)).toEqual(["^user\\/.+$"]);
+     expect(config.repositories[0]?.allowedBranchPatterns.map((pattern) => pattern.source)).toEqual([
+      "^(?:^user\\/.+$)$",
+    ]);
      expect(config.repositories[0]?.featureBranchPattern).toBe("user/<feature-name>");
      expect(config.repositories[0]?.gitWorktreeBasePath).toBe(expectedBasePath);
      expect(config.repositories[0]?.defaultRemote).toBe("upstream");
@@ -119,7 +142,9 @@ describe("loadConfig", () => {
 
     const config = await loadConfig(configPath);
 
-    expect(config.repositories[0]?.allowedBranchPatterns.map((pattern) => pattern.source)).toEqual(["^codex\\/.+$"]);
+    expect(config.repositories[0]?.allowedBranchPatterns.map((pattern) => pattern.source)).toEqual([
+      "^(?:^codex\\/.+$)$",
+    ]);
   });
 
   it("escapes regex metacharacters when resolving <user> in allowed branch patterns", async () => {
@@ -144,7 +169,7 @@ describe("loadConfig", () => {
     const config = await loadConfig(configPath);
     const [pattern] = config.repositories[0]?.allowedBranchPatterns ?? [];
 
-    expect(pattern?.source).toBe("^john\\.doe\\+dev\\/.+$");
+    expect(pattern?.source).toBe("^(?:^john\\.doe\\+dev\\/.+$)$");
     expect(pattern?.test("john.doe+dev/feature")).toBe(true);
     expect(pattern?.test("johnXdoe+dev/feature")).toBe(false);
   });
@@ -290,7 +315,9 @@ describe("loadConfig", () => {
 
     const config = await loadConfig(configPath);
 
-     expect(config.repositories[0]?.allowedBranchPatterns.map((pattern) => pattern.source)).toEqual(["^feature\\/.+$"]);
+     expect(config.repositories[0]?.allowedBranchPatterns.map((pattern) => pattern.source)).toEqual([
+      "^(?:^feature\\/.+$)$",
+    ]);
      expect(config.repositories[0]?.featureBranchPattern).toBe("feature/<feature-name>");
      expect(config.repositories[0]?.gitWorktreeBasePath).toBe(expectedWorktreeBasePath);
      expect(config.repositories[0]?.defaultRemote).toBe("origin");

--- a/tests/gitRepoPolicy.test.ts
+++ b/tests/gitRepoPolicy.test.ts
@@ -9,7 +9,7 @@ describe("getGitRepoPolicy", () => {
       path: "/tmp/repo",
       canonicalPath: "/private/tmp/repo",
       worktreePath: "/private/tmp/repo",
-      allowedBranchPatterns: [/^user\/.*$/, /^feature\/[a-z0-9._-]+$/],
+      allowedBranchPatterns: [/^(?:^user\/.*$)$/, /^(?:^feature\/[a-z0-9._-]+$)$/],
       featureBranchPattern: "codex/<feature-name>",
       gitWorktreeBasePath: "/private/tmp/worktrees",
       defaultRemote: "origin",
@@ -23,7 +23,7 @@ describe("getGitRepoPolicy", () => {
     expect(getGitRepoPolicy(repo)).toEqual({
       path: "/tmp/repo",
       canonicalPath: "/private/tmp/repo",
-      allowedBranchPatterns: ["^user\\/.*$", "^feature\\/[a-z0-9._-]+$"],
+      allowedBranchPatterns: ["^(?:^user\\/.*$)$", "^(?:^feature\\/[a-z0-9._-]+$)$"],
       featureBranchPattern: "codex/<feature-name>",
       gitWorktreeBasePath: "/private/tmp/worktrees",
       defaultRemote: "origin",

--- a/tests/repoAuth.test.ts
+++ b/tests/repoAuth.test.ts
@@ -86,7 +86,7 @@ describe("resolveAllowedRepo", () => {
     expect(resolvedRepo.repoLocalConfigPath).toBe(path.join(canonicalRepoDir, ".git-unleash.yaml"));
     expect(resolvedRepo.featureBranchPattern).toBe("codex/<feature-name>");
     expect(resolvedRepo.gitWorktreeBasePath).toBe(path.join(canonicalRepoDir, ".worktrees"));
-    expect(resolvedRepo.allowedBranchPatterns.map((pattern) => pattern.source)).toEqual(["^codex\\/.+$"]);
+    expect(resolvedRepo.allowedBranchPatterns.map((pattern) => pattern.source)).toEqual(["^(?:^codex\\/.+$)$"]);
   });
 
   it("allows matching global repo entries to override repo-local policy", async () => {
@@ -266,7 +266,7 @@ describe("resolveAllowedRepo", () => {
     expect(resolvedRepo.allowDraftPrs).toBe(true);
     expect(resolvedRepo.workflowMode).toBe("worktree");
     expect(resolvedRepo.defaultRemote).toBeUndefined();
-    expect(resolvedRepo.allowedBranchPatterns.map((pattern) => pattern.source)).toEqual(["^owner\\/.+$"]);
+    expect(resolvedRepo.allowedBranchPatterns.map((pattern) => pattern.source)).toEqual(["^(?:^owner\\/.+$)$"]);
     expect(resolvedRepo.repoOverridesApplied).toBe(false);
   });
 
@@ -295,7 +295,7 @@ describe("resolveAllowedRepo", () => {
 
     expect(resolvedRepo.policySource).toBe("repo_local");
     expect(resolvedRepo.canonicalPath).toBe(canonicalRepoDir);
-    expect(resolvedRepo.allowedBranchPatterns.map((pattern) => pattern.source)).toEqual(["^owner\\/.+$"]);
+    expect(resolvedRepo.allowedBranchPatterns.map((pattern) => pattern.source)).toEqual(["^(?:^owner\\/.+$)$"]);
     expect(resolvedRepo.featureBranchPattern).toBe("owner/<feature-name>");
     expect(resolvedRepo.repoOverridesApplied).toBe(false);
   });


### PR DESCRIPTION
## Why
Issue #48 asked to move full-match anchoring into policy construction, and this PR does that in `compileBranchPatterns()`.

I intentionally did not keep the follow-on `fullMatch()` optimization of reusing the same `RegExp` instance in place. Cloning the compiled regex per call keeps matching free of implicit `lastIndex` mutation and shared mutable regex state, and the added cost is negligible on this app's git-tool paths relative to the surrounding git subprocess work.

## Impact
Allowed branch policy regexes are still compiled once into anchored full-match form during config loading. `fullMatch()` now clones that compiled regex before `.test()` so the helper stays mutation-free while preserving full-match behavior.

## Verification
- `npm test -- tests/branchAuth.test.ts`
- `npm test`
- `npm run typecheck`

Closes #48